### PR TITLE
Add feature optimization utilities with Optuna

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [訓練（scripts\train_multi.py）](#訓練scriptstrain_multipy)
   - [回測（scripts\backtest_multi.py）](#回測scriptsbacktest_multipy)
   - [即時（scripts\realtime_multi.py / scripts\realtime_loop.py）](#即時scriptsrealtime_multipy--scriptsrealtime_looppy)
+  - [特徵優化（scripts\feature_optimize.py）](#特徵優化scriptsfeature_optimizepy)
 - [日期區間功能說明](#日期區間功能說明)
 - [輸出與檔案位置](#輸出與檔案位置)
 - [常見問題 FAQ](#常見問題-faq)
@@ -170,6 +171,20 @@ python scripts\realtime_multi.py --cfg csp\configs\strategy.yaml
 set START_DATE=2025-08-01
 set END_DATE=2025-08-10
 python scripts\realtime_loop.py --cfg csp\configs\strategy.yaml --delay-sec 15
+```
+
+---
+
+### 特徵優化（`scripts\feature_optimize.py`）
+- **用途**：利用 Optuna 搜索特徵參數，逐幣回測評估。
+- **常用參數**：
+  - `--cfg <path>`：指定設定檔。
+  - `--symbols <sym ...>`：指定幣別（預設讀 cfg.symbols）。
+  - `--days <N>`：回測天數（或配合環境變數 START_DATE/END_DATE）。
+  - `--trials <N>`：Optuna 試驗次數。
+- **範例**：
+```cmd
+python scripts\feature_optimize.py --cfg csp\configs\strategy.yaml --symbols BTCUSDT --days 30 --trials 10
 ```
 
 ---

--- a/csp/optimize/__init__.py
+++ b/csp/optimize/__init__.py
@@ -1,0 +1,11 @@
+"""Feature optimization utilities."""
+from .featurizer import add_features
+from .evaluator import walk_forward_evaluate
+from .feature_opt import optimize_symbol, optimize_symbols
+
+__all__ = [
+    "add_features",
+    "walk_forward_evaluate",
+    "optimize_symbol",
+    "optimize_symbols",
+]

--- a/csp/optimize/evaluator.py
+++ b/csp/optimize/evaluator.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import os
+import tempfile
+from copy import deepcopy
+from typing import Dict, Any
+
+import pandas as pd
+import yaml
+
+from csp.backtesting.backtest_v2 import run_backtest_for_symbol
+
+
+def walk_forward_evaluate(cfg_path: str, symbol: str,
+                          start_ts: pd.Timestamp, end_ts: pd.Timestamp,
+                          feature_params: Dict[str, Any]) -> Dict[str, Any]:
+    """Evaluate ``feature_params`` by running the existing backtest logic.
+
+    A temporary config file is created with the feature parameters injected
+    so that ``run_backtest_for_symbol`` can remain unchanged.
+    """
+    cfg = yaml.safe_load(open(cfg_path, "r", encoding="utf-8"))
+    cfg2 = deepcopy(cfg)
+    cfg2.setdefault("feature", {}).update(feature_params)
+
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as tmp:
+        yaml.safe_dump(cfg2, tmp, allow_unicode=True)
+        tmp_path = tmp.name
+    try:
+        csv_path = cfg2["io"]["csv_paths"][symbol]
+        res = run_backtest_for_symbol(
+            csv_path,
+            tmp_path,
+            symbol=symbol,
+            start_ts=start_ts,
+            end_ts=end_ts,
+        )
+    finally:
+        os.unlink(tmp_path)
+    return res

--- a/csp/optimize/feature_opt.py
+++ b/csp/optimize/feature_opt.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+from pathlib import Path
+import json
+from typing import Dict, List
+
+import optuna
+import pandas as pd
+import yaml
+
+from .evaluator import walk_forward_evaluate
+
+
+def _suggest_params(trial: optuna.Trial) -> Dict:
+    """Search space for feature parameters.
+
+    EMA windows are kept fixed to avoid mismatch with trained models.
+    """
+    return {
+        # keep ema_windows from config
+        "rsi_window": trial.suggest_int("rsi_window", 5, 30),
+        "bb_window": trial.suggest_int("bb_window", 10, 40),
+        "bb_std": trial.suggest_float("bb_std", 1.0, 3.5),
+        "atr_window": trial.suggest_int("atr_window", 7, 40),
+    }
+
+
+def optimize_symbol(cfg_path: str, symbol: str,
+                    start_ts: pd.Timestamp, end_ts: pd.Timestamp,
+                    n_trials: int = 20, out_dir: Path | None = None) -> optuna.Study:
+    """Run Optuna optimization for a single symbol."""
+    cfg = yaml.safe_load(open(cfg_path, "r", encoding="utf-8"))
+    base_feature = cfg.get("feature", {})
+
+    def objective(trial: optuna.Trial) -> float:
+        params = _suggest_params(trial)
+        # merge with base feature params (e.g., ema_windows)
+        merged = {**base_feature, **params}
+        res = walk_forward_evaluate(cfg_path, symbol, start_ts, end_ts, merged)
+        metric = res.get("metrics", {}).get("總報酬率%", 0.0)
+        trial.set_user_attr("metrics", res.get("metrics", {}))
+        return float(metric)
+
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=n_trials)
+
+    if out_dir is not None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        # trials dataframe
+        df = study.trials_dataframe()
+        df.to_csv(out_dir / f"{symbol}_trials.csv", index=False, encoding="utf-8-sig")
+        # best summary
+        summary = {
+            "best_value": study.best_value,
+            "best_params": study.best_params,
+        }
+        (out_dir / f"{symbol}_best.json").write_text(
+            json.dumps(summary, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    return study
+
+
+def optimize_symbols(cfg_path: str, symbols: List[str],
+                     start_ts: pd.Timestamp, end_ts: pd.Timestamp,
+                     n_trials: int = 20, out_dir: Path | None = None) -> Dict[str, optuna.Study]:
+    results: Dict[str, optuna.Study] = {}
+    for sym in symbols:
+        study = optimize_symbol(cfg_path, sym, start_ts, end_ts, n_trials, out_dir)
+        results[sym] = study
+    return results

--- a/csp/optimize/featurizer.py
+++ b/csp/optimize/featurizer.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from typing import Dict, Any
+import pandas as pd
+
+from csp.features.h16 import build_features_15m_4h
+
+
+def default_params() -> Dict[str, Any]:
+    return {
+        "ema_windows": (9, 21, 50),
+        "rsi_window": 14,
+        "bb_window": 20,
+        "bb_std": 2.0,
+        "atr_window": 14,
+        "h4_resample": "4H",
+    }
+
+
+def add_features(df: pd.DataFrame, params: Dict[str, Any] | None = None) -> pd.DataFrame:
+    """Add technical features to ``df`` using the given ``params``.
+
+    Parameters are aligned with ``strategy.yaml`` and the existing
+    training/realtime feature set.
+    """
+    p = default_params()
+    if params:
+        p.update(params)
+    feats = build_features_15m_4h(
+        df,
+        ema_windows=tuple(p["ema_windows"]),
+        rsi_window=int(p["rsi_window"]),
+        bb_window=int(p["bb_window"]),
+        bb_std=float(p["bb_std"]),
+        atr_window=int(p["atr_window"]),
+        h4_resample=p.get("h4_resample", "4H"),
+    )
+    return feats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
   "pyyaml",
   "requests",
   "joblib",
-  "python-dateutil"
+  "python-dateutil",
+  "optuna"
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyyaml
 requests
 joblib
 python-dateutil
+optuna

--- a/scripts/feature_optimize.py
+++ b/scripts/feature_optimize.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from csp.data.loader import load_15m_csv
+from csp.utils.dates import resolve_time_range_like
+from csp.optimize.feature_opt import optimize_symbol
+
+
+def _read_date_args_from_env() -> dict:
+    start = os.getenv("START_DATE")
+    end = os.getenv("END_DATE")
+    days = os.getenv("DAYS")
+    if days is not None:
+        try:
+            days = int(days)
+        except Exception:
+            days = None
+    return {"start": start, "end": end, "days": days}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cfg", required=True, help="path to strategy.yaml")
+    ap.add_argument("--symbols", nargs="*", default=None, help="指定要跑的幣別")
+    ap.add_argument("--days", type=int, default=None, help="回測天數（未指定 start/end 時生效）")
+    ap.add_argument("--trials", type=int, default=20, help="Optuna trials 數")
+    ap.add_argument("--outdir", default="reports/feature_opt", help="輸出目錄")
+    args = ap.parse_args()
+
+    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    symbols = args.symbols or cfg.get("symbols", [])
+    if not symbols:
+        print("cfg.symbols 為空，請在 strategy.yaml 設定幣別")
+        sys.exit(1)
+
+    base_out = Path(args.outdir)
+    base_out.mkdir(parents=True, exist_ok=True)
+
+    env_args = _read_date_args_from_env()
+    if args.days is not None:
+        env_args["days"] = args.days
+
+    for sym in symbols:
+        csv_path = cfg["io"]["csv_paths"][sym]
+        df = load_15m_csv(csv_path)
+        idx = pd.DatetimeIndex(df["timestamp"])
+        start_ts, end_ts = resolve_time_range_like(env_args, idx)
+        print(f"[OPT] {sym} {start_ts}~{end_ts} trials={args.trials}")
+        study = optimize_symbol(args.cfg, sym, start_ts, end_ts, args.trials, base_out)
+        print(f"[BEST {sym}] value={study.best_value:.6f} params={study.best_params}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `csp.optimize` package for feature engineering and walk-forward evaluation
- integrate Optuna-based feature search with per-symbol trial logging
- provide `scripts/feature_optimize.py` CLI and document usage
- include Optuna dependency

## Testing
- `pip install optuna` *(fails: Could not connect to proxy)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fdbc131b8832da39bbb1019e79a82