### PR TITLE
feat: per-symbol feature configuration and auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,13 @@ python scripts\realtime_loop.py --cfg csp\configs\strategy.yaml --delay-sec 15
 - **用途**：利用 Optuna 搜索特徵參數，逐幣回測評估。
 - **常用參數**：
   - `--cfg <path>`：指定設定檔。
-  - `--symbols <sym ...>`：指定幣別（預設讀 cfg.symbols）。
+  - `--symbols sym1,sym2`：以逗號分隔的幣別清單（預設讀 cfg.symbols）。
   - `--days <N>`：回測天數（或配合環境變數 START_DATE/END_DATE）。
   - `--trials <N>`：Optuna 試驗次數。
+  - `--apply-to-cfg`：將最佳參數寫回 `strategy.yaml`。
 - **範例**：
 ```cmd
-python scripts\feature_optimize.py --cfg csp\configs\strategy.yaml --symbols BTCUSDT --days 30 --trials 10
+python scripts\feature_optimize.py --cfg csp\configs\strategy.yaml --symbols BTCUSDT,ETHUSDT --days 30 --trials 10 --apply-to-cfg
 ```
 
 ---

--- a/csp/configs/strategy.yaml
+++ b/csp/configs/strategy.yaml
@@ -15,18 +15,27 @@ io:
     interval: 15m
     limit: 96
     api_base: https://api.binance.com
-feature:
-  ema_windows:
-  - 9
-  - 21
-  - 50
-  rsi_window: 14
-  bb_window: 20
-  bb_std: 2.0
-  atr_window: 14
-  h4_rule:
-    enabled: true
-    resample: 4H
+features:
+  default:
+    ema_windows:
+    - 9
+    - 21
+    - 50
+    h4_rule:
+      enabled: true
+      resample: 4H
+    rsi: {enabled: true, window: 14}
+    bollinger: {enabled: true, window: 20, std: 2.0}
+    atr: {enabled: true, window: 14}
+  per_symbol:
+    BTCUSDT:
+      rsi: {enabled: true, window: 20}
+      bollinger: {enabled: true, window: 24, std: 3.42}
+      atr: {enabled: true, window: 17}
+    ETHUSDT:
+      rsi: {enabled: true, window: 14}
+      bollinger: {enabled: true, window: 20, std: 2.0}
+      atr: {enabled: true, window: 14}
 train:
   target_horizon_bars: 16
   label_threshold: 0.0

--- a/csp/optimize/__init__.py
+++ b/csp/optimize/__init__.py
@@ -1,11 +1,12 @@
 """Feature optimization utilities."""
 from .featurizer import add_features
 from .evaluator import walk_forward_evaluate
-from .feature_opt import optimize_symbol, optimize_symbols
+from .feature_opt import optimize_symbol, optimize_symbols, apply_best_params_to_cfg
 
 __all__ = [
     "add_features",
     "walk_forward_evaluate",
     "optimize_symbol",
     "optimize_symbols",
+    "apply_best_params_to_cfg",
 ]

--- a/csp/optimize/evaluator.py
+++ b/csp/optimize/evaluator.py
@@ -20,7 +20,21 @@ def walk_forward_evaluate(cfg_path: str, symbol: str,
     """
     cfg = yaml.safe_load(open(cfg_path, "r", encoding="utf-8"))
     cfg2 = deepcopy(cfg)
-    cfg2.setdefault("feature", {}).update(feature_params)
+    feats = cfg2.setdefault("features", {})
+    default = feats.setdefault("default", {})
+    per = feats.setdefault("per_symbol", {})
+    sym_cfg = per.setdefault(symbol, {})
+    sym_cfg.setdefault("rsi", {})
+    sym_cfg.setdefault("bollinger", {})
+    sym_cfg.setdefault("atr", {})
+    sym_cfg["rsi"]["window"] = int(feature_params["rsi_window"])
+    sym_cfg["bollinger"]["window"] = int(feature_params["bb_window"])
+    sym_cfg["bollinger"]["std"] = float(feature_params["bb_std"])
+    sym_cfg["atr"]["window"] = int(feature_params["atr_window"])
+    # base parameters
+    default["ema_windows"] = feature_params.get("ema_windows", default.get("ema_windows", (9, 21, 50)))
+    h4_rule = default.setdefault("h4_rule", {})
+    h4_rule["resample"] = feature_params.get("h4_resample", h4_rule.get("resample", "4H"))
 
     with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as tmp:
         yaml.safe_dump(cfg2, tmp, allow_unicode=True)

--- a/csp/utils/config.py
+++ b/csp/utils/config.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from typing import Dict, Any
+
+
+def get_symbol_features(cfg: Dict[str, Any], symbol: str) -> Dict[str, Any]:
+    """Return merged feature parameters for ``symbol``.
+
+    Configuration format::
+
+        features:
+          default:
+            rsi: {enabled: true, window: 14}
+            bollinger: {enabled: true, window: 20, std: 2.0}
+            atr: {enabled: true, window: 14}
+          per_symbol:
+            BTCUSDT:
+              rsi: {enabled: true, window: 20}
+              ...
+
+    The function first reads ``features.default`` then overrides with
+    ``features.per_symbol.<SYMBOL>`` if present.  The returned dictionary
+    is flattened to match the historical ``feature`` parameters used by the
+    feature builders.
+    """
+    feats = cfg.get("features", {})
+    default = feats.get("default", {})
+    per_sym = feats.get("per_symbol", {}).get(symbol, {})
+
+    def merge(name: str) -> Dict[str, Any]:
+        res: Dict[str, Any] = {}
+        if isinstance(default.get(name), dict):
+            res.update(default[name])
+        if isinstance(per_sym.get(name), dict):
+            res.update(per_sym[name])
+        return res
+
+    out: Dict[str, Any] = {}
+    # parameters used by build_features_15m_4h
+    out["ema_windows"] = default.get("ema_windows", (9, 21, 50))
+    h4_rule = default.get("h4_rule", {"resample": "4H"})
+    out["h4_rule"] = h4_rule
+    out["h4_resample"] = h4_rule.get("resample", "4H")
+
+    rsi = merge("rsi")
+    boll = merge("bollinger")
+    atr = merge("atr")
+
+    out.update({
+        "rsi_window": int(rsi.get("window", 14)),
+        "bb_window": int(boll.get("window", 20)),
+        "bb_std": float(boll.get("std", 2.0)),
+        "atr_window": int(atr.get("window", 14)),
+    })
+    return out

--- a/tests/test_config_features.py
+++ b/tests/test_config_features.py
@@ -1,0 +1,55 @@
+import pathlib, sys, yaml
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from csp.utils.config import get_symbol_features
+from csp.optimize.feature_opt import apply_best_params_to_cfg
+
+
+def _sample_cfg():
+    return {
+        "features": {
+            "default": {
+                "ema_windows": [9, 21, 50],
+                "h4_rule": {"enabled": True, "resample": "4H"},
+                "rsi": {"enabled": True, "window": 14},
+                "bollinger": {"enabled": True, "window": 20, "std": 2.0},
+                "atr": {"enabled": True, "window": 14},
+            },
+            "per_symbol": {
+                "BTCUSDT": {
+                    "rsi": {"enabled": True, "window": 20},
+                    "bollinger": {"enabled": True, "window": 24, "std": 3.42},
+                    "atr": {"enabled": True, "window": 17},
+                }
+            },
+        },
+    }
+
+
+def test_get_symbol_features_merge():
+    cfg = _sample_cfg()
+    btc = get_symbol_features(cfg, "BTCUSDT")
+    assert btc["rsi_window"] == 20
+    assert btc["bb_window"] == 24
+    assert abs(btc["bb_std"] - 3.42) < 1e-9
+    assert btc["atr_window"] == 17
+
+    eth = get_symbol_features(cfg, "ETHUSDT")
+    assert eth["rsi_window"] == 14
+    assert eth["bb_window"] == 20
+    assert eth["atr_window"] == 14
+
+
+def test_apply_best_params(tmp_path):
+    cfg = _sample_cfg()
+    cfg_path = tmp_path / "s.yaml"
+    cfg_path.write_text(yaml.dump(cfg, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    best = {"rsi_window": 8, "bb_window": 30, "bb_std": 1.5, "atr_window": 10}
+    log_file = tmp_path / "log.txt"
+    apply_best_params_to_cfg(cfg_path, "ETHUSDT", best, apply=True, log_file=log_file)
+    updated = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    eth_cfg = updated["features"]["per_symbol"]["ETHUSDT"]
+    assert eth_cfg["rsi"]["window"] == 8
+    assert eth_cfg["bollinger"]["window"] == 30
+    assert float(eth_cfg["bollinger"]["std"]) == 1.5
+    assert eth_cfg["atr"]["window"] == 10
+    assert log_file.exists()


### PR DESCRIPTION
## Summary
- support `features.default` and `features.per_symbol` in strategy config
- add helper to merge per-symbol feature parameters
- feature optimization CLI can update strategy.yaml with a backup and diff

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a6334008832db680cdd944de590f