### PR TITLE
feat: add feature order checks and diagnostics

### DIFF
--- a/csp/diagnostics/proba_diag.py
+++ b/csp/diagnostics/proba_diag.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import joblib
+import numpy as np
+import xgboost as xgb
+
+from csp.features.h16 import build_features_15m_4h
+from csp.utils.config import get_symbol_features
+
+
+def load_io_from_cfg(cfg: Dict[str, Any], symbol: str) -> Dict[str, Any]:
+    csv_path = cfg.get("io", {}).get("csv_paths", {}).get(symbol)
+    models_root = Path(cfg.get("io", {}).get("models_dir", "models")) / symbol
+    feat_params = get_symbol_features(cfg, symbol)
+    return {"csv_path": csv_path, "models_dir": models_root, "feat_params": feat_params}
+
+
+def load_model_and_scaler(paths: Dict[str, Any], symbol: str, horizon: int) -> Dict[str, Any]:
+    models_root = Path(paths["models_dir"])
+    mdir = models_root / f"h{horizon}"
+    if not mdir.exists():
+        mdir = models_root
+
+    feature_path = models_root / "feature_names.json"
+    if not feature_path.exists():
+        raise FileNotFoundError(f"feature_names.json not found for {symbol} under {models_root}")
+    feature_names = json.load(open(feature_path, "r", encoding="utf-8"))
+
+    model_path_joblib = mdir / f"xgb_h{horizon}_sklearn.joblib"
+    model_path_json = mdir / f"xgb_h{horizon}.json"
+    scaler_path = mdir / f"scaler_h{horizon}.joblib"
+    meta_path = mdir / f"meta_h{horizon}.json"
+
+    if model_path_joblib.exists():
+        model = joblib.load(model_path_joblib)
+        model_type = "sklearn"
+        model_path = model_path_joblib
+    elif model_path_json.exists():
+        model = xgb.Booster(); model.load_model(str(model_path_json))
+        model_type = "booster"
+        model_path = model_path_json
+    else:
+        raise FileNotFoundError(f"No model file found under {mdir}")
+
+    scaler = joblib.load(scaler_path)
+    positive_ratio: Optional[float] = None
+    if meta_path.exists():
+        meta = json.load(open(meta_path, "r", encoding="utf-8"))
+        positive_ratio = meta.get("positive_ratio")
+
+    return {
+        "model": model,
+        "scaler": scaler,
+        "feature_names": feature_names,
+        "model_path": str(model_path),
+        "scaler_path": str(scaler_path),
+        "feature_names_path": str(feature_path),
+        "model_type": model_type,
+        "positive_ratio": positive_ratio,
+    }
+
+
+def build_features(df, horizon: int, feat_params: Dict[str, Any]):
+    feats = build_features_15m_4h(
+        df,
+        ema_windows=tuple(feat_params["ema_windows"]),
+        rsi_window=feat_params["rsi_window"],
+        bb_window=feat_params["bb_window"],
+        bb_std=feat_params["bb_std"],
+        atr_window=feat_params["atr_window"],
+        h4_resample=feat_params["h4_resample"],
+    )
+    return feats, list(feats.columns)
+
+
+def infer_proba(model, X: np.ndarray, api: str, feature_names: Optional[Iterable[str]] = None) -> np.ndarray:
+    if api == "sklearn":
+        return np.clip(model.predict_proba(X)[:, 1], 0.0, 1.0)
+    dmat = xgb.DMatrix(X, feature_names=list(feature_names) if feature_names else None)
+    return np.clip(model.predict(dmat, output_margin=False), 0.0, 1.0)
+
+
+def summarize_proba(prob_up: np.ndarray, last_n: int = 200) -> Dict[str, float]:
+    if prob_up.size == 0:
+        return {"p50": np.nan, "p90": np.nan, "max": np.nan, "mean": np.nan}
+    tail = prob_up[-last_n:]
+    return {
+        "p50": float(np.percentile(tail, 50)),
+        "p90": float(np.percentile(tail, 90)),
+        "max": float(np.max(tail)),
+        "mean": float(np.mean(tail)),
+    }
+
+
+def sanity_checks(row: np.ndarray) -> Dict[str, float]:
+    return {
+        "has_nan": bool(np.isnan(row).any()),
+        "has_inf": bool(np.isinf(row).any()),
+        "min": float(np.min(row)),
+        "max": float(np.max(row)),
+        "mean": float(np.mean(row)),
+    }
+
+
+def print_debug(enabled: bool, *, symbol: str, model_path: str, scaler_path: str,
+                feature_names_path: str, X: np.ndarray, summary: Dict[str, float],
+                sanity: Dict[str, float], last_n: int) -> None:
+    if not (enabled or os.environ.get("DEBUG") == "1"):
+        return
+    print(f"symbol={symbol}")
+    print(f"model_path={model_path}")
+    print(f"scaler_path={scaler_path}")
+    print(f"feature_names_path={feature_names_path}")
+    print(f"X.shape={X.shape}")
+    print(f"last row has NaN? {sanity['has_nan']} / inf? {sanity['has_inf']}")
+    print(
+        f"last row stats: min={sanity['min']:.6f}, max={sanity['max']:.6f}, mean={sanity['mean']:.6f}"
+    )
+    print(
+        f"proba_up last{last_n} p50={summary['p50']:.6f}, "
+        f"p90={summary['p90']:.6f}, max={summary['max']:.6f}, mean={summary['mean']:.6f}"
+    )
+

--- a/scripts/diag_proba.py
+++ b/scripts/diag_proba.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+import argparse
+from pathlib import Path
+import pandas as pd
+import yaml
+
+from csp.diagnostics import proba_diag
+from csp.data.loader import load_15m_csv
+from csp.pipeline.realtime_v2 import initialize_history
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cfg", default="csp/configs/strategy.yaml")
+    ap.add_argument("--symbol")
+    ap.add_argument("--all", action="store_true")
+    ap.add_argument("--horizon", nargs="+", type=int, default=[2, 4, 8, 16, 48, 192])
+    ap.add_argument("--last-n", type=int, default=200)
+    ap.add_argument("--debug", action="store_true")
+    ap.add_argument("--use-model-of")
+    ap.add_argument("--save-report")
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+
+    if args.all:
+        symbols = cfg.get("symbols", [])
+    elif args.symbol:
+        symbols = [args.symbol]
+    else:
+        raise SystemExit("--symbol or --all required")
+
+    model_override = args.use_model_of
+    results = []
+
+    for sym in symbols:
+        try:
+            paths = proba_diag.load_io_from_cfg(cfg, sym)
+            if not paths.get("csv_path"):
+                raise FileNotFoundError(f"csv path not found for {sym}")
+            df = load_15m_csv(paths["csv_path"])
+            df = initialize_history(df)
+            feat_df, _ = proba_diag.build_features(df, max(args.horizon), paths["feat_params"])
+        except Exception as e:
+            for h in args.horizon:
+                results.append({"symbol": sym, "horizon": h, "status": "ERROR", "error": str(e)})
+            continue
+
+        for h in args.horizon:
+            model_sym = model_override if model_override else sym
+            try:
+                model_paths = proba_diag.load_io_from_cfg(cfg, model_sym)
+                bundle = proba_diag.load_model_and_scaler(model_paths, model_sym, h)
+                feature_names = bundle["feature_names"]
+                X = feat_df[feature_names].values
+                Xs = bundle["scaler"].transform(X)
+                proba_seq = proba_diag.infer_proba(
+                    bundle["model"], Xs, api=bundle["model_type"], feature_names=feature_names
+                )
+                summary = proba_diag.summarize_proba(proba_seq, last_n=args.last_n)
+                sanity = proba_diag.sanity_checks(Xs[-1])
+                proba_diag.print_debug(
+                    args.debug,
+                    symbol=sym,
+                    model_path=bundle["model_path"],
+                    scaler_path=bundle["scaler_path"],
+                    feature_names_path=bundle["feature_names_path"],
+                    X=Xs,
+                    summary=summary,
+                    sanity=sanity,
+                    last_n=args.last_n,
+                )
+                results.append(
+                    {
+                        "symbol": sym,
+                        "horizon": h,
+                        "positive_ratio": bundle.get("positive_ratio", "N/A"),
+                        "proba_p50": summary["p50"],
+                        "proba_p90": summary["p90"],
+                        "proba_max": summary["max"],
+                        "proba_mean": summary["mean"],
+                        "X_last_min": sanity["min"],
+                        "X_last_max": sanity["max"],
+                        "X_last_mean": sanity["mean"],
+                        "has_nan": sanity["has_nan"],
+                        "has_inf": sanity["has_inf"],
+                        "model_path": bundle["model_path"],
+                        "scaler_path": bundle["scaler_path"],
+                        "feature_names_path": bundle["feature_names_path"],
+                        "cross_model_symbol": model_override if model_override else "",
+                        "status": "OK",
+                    }
+                )
+            except Exception as e:
+                results.append(
+                    {
+                        "symbol": sym,
+                        "horizon": h,
+                        "status": "ERROR",
+                        "error": str(e),
+                        "cross_model_symbol": model_override if model_override else "",
+                    }
+                )
+
+    df_res = pd.DataFrame(results)
+    if args.save_report:
+        out_path = Path(args.save_report)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        df_res.to_csv(out_path, index=False)
+    else:
+        print(df_res)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/predict_and_notify.py
+++ b/scripts/predict_and_notify.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import argparse
+import json
+import yaml
+
+from csp.pipeline.realtime_v2 import run_once
+from csp.utils.notifier import notify
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", required=True, help="Path to 15m CSV (latest rows used)")
+    ap.add_argument("--cfg", default="csp/configs/strategy.yaml")
+    ap.add_argument("--debug", action="store_true")
+    args = ap.parse_args()
+
+    res = run_once(args.csv, args.cfg, debug=args.debug)
+    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+
+    if "error" in res:
+        line = f"{res.get('symbol', '?')}: ERROR {res['error']}"
+    else:
+        side_display = res["side"].upper() if res.get("side") else "WAIT"
+        line = f"{res['symbol']}: {side_display} | P={res['price']:.2f} | proba_up={res['proba_up']:.3f}"
+        if res.get("side"):
+            line += f" | TP={res['tp']:.2f} | SL={res['sl']:.2f}"
+        if res.get("diag_low_var"):
+            line += " [DIAG:LOW VAR]"
+    notify(line, cfg.get("notify", {}).get("telegram"))
+    print(json.dumps(res, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/realtime.py
+++ b/scripts/realtime.py
@@ -5,6 +5,7 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--csv", required=True, help="Path to 15m CSV (latest rows used)")
     ap.add_argument("--cfg", default="csp/configs/strategy.yaml")
+    ap.add_argument("--debug", action="store_true")
     args = ap.parse_args()
-    out = run_once(args.csv, args.cfg)
+    out = run_once(args.csv, args.cfg, debug=args.debug)
     print(out)

--- a/scripts/realtime_multi.py
+++ b/scripts/realtime_multi.py
@@ -14,6 +14,7 @@ from csp.utils.notifier import notify
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--cfg", default="csp/configs/strategy.yaml")
+    ap.add_argument("--debug", action="store_true")
     args = ap.parse_args()
 
     cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
@@ -41,7 +42,7 @@ def main():
                 stale = True
         try:
             # run_once 會自動挑選 models/<SYMBOL>/ 或全域 models/
-            res = run_once(csv_path, cfg_path=args.cfg)
+            res = run_once(csv_path, cfg_path=args.cfg, debug=args.debug)
         except Exception as e:
             res = {"symbol": sym, "side": None, "error": str(e)}
         if stale:
@@ -65,6 +66,8 @@ def main():
         base = f"{sym}: {side_display} | P={price:.2f} | proba_up={pu:.3f}{note}"
         if r.get("side"):
             base += f" | TP={tp:.2f} | SL={sl:.2f}"
+        if r.get("diag_low_var"):
+            base += " [DIAG:LOW VAR]"
         lines.append(base)
 
     msg = "\n".join(lines)

--- a/scripts/train_multi.py
+++ b/scripts/train_multi.py
@@ -21,4 +21,9 @@ if __name__ == "__main__":
         out_dir = base_models / sym
         out_dir.mkdir(parents=True, exist_ok=True)
         print(f"[TRAIN] {sym} <- {csv_path}  -> {out_dir}")
-        train(csv_path, args.cfg, models_dir_override=str(out_dir))
+        res = train(csv_path, args.cfg, models_dir_override=str(out_dir), symbol=sym)
+        pr = res.get("positive_ratio")
+        if pr is not None:
+            print(f"[INFO] {sym} positive ratio={pr:.4f}")
+        if res.get("warning"):
+            print(f"[WARN] {sym}: {res['warning']}")


### PR DESCRIPTION
## Summary
- save feature name order and class balance during training with ETH warning
- enforce per-symbol model/scaler loading and add debug diagnostics
- add realtime diagnostic scripts and low variance alert
- generalize diagnostic script with reusable module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5f675a9a0832d8572a3f5d047f018