### PR TITLE
Add summary metrics reporting for backtests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Crypto Strategy Project — 使用說明（Windows / CMD 版）
 > 版本日期：2025-08-15
 
-本專案提供「**訓練** → **回測** → **即時訊號**」的一條龍流程，使用 15 分鐘 K 線資料建立模型，並在即時模式推送多幣別整合訊息。  
-**重點更新**：支援「**日期區間**」功能（以本地 UTC+8 自然日解析），可精準指定訓練/初始化所用的歷史範圍。
+本專案提供「**訓練** → **回測** → **即時訊號**」的一條龍流程，使用 15 分鐘 K 線資料建立模型，並在即時模式推送多幣別整合訊息。
+**重點更新**：
+- 支援「**日期區間**」功能（以本地 UTC+8 自然日解析），可精準指定訓練/初始化所用的歷史範圍。
+- 回測可輸出完整績效摘要與交易明細，支援 CSV / JSON 報表。
 
 ---
 
@@ -92,10 +94,12 @@ python scripts\train_multi.py --cfg csp\configs\strategy.yaml
 
 ### 回測（多幣）
 ```cmd
-python scripts\backtest_multi.py --cfg csp\configs\strategy.yaml --days 30 --fetch inc --save-summary
+python scripts\backtest_multi.py --cfg csp\configs\strategy.yaml --days 30 --fetch inc --save-summary --out-dir reports --format both
 ```
 - `--days 30`：取最近 30 天資料。
 - `--fetch inc`：只補缺口；用 `--fetch full` 可完整覆蓋重抓。
+- `--out-dir reports`：報表輸出目錄（預設 `reports`）。
+- `--format both`：報表格式，可選 `csv`、`json` 或 `both`。
 
 ### 即時訊號
 ```cmd
@@ -141,19 +145,21 @@ python scripts\train_multi.py --cfg csp\configs\strategy.yaml
   - `--export-equity-bars <path.csv>`：輸出等時間柱狀的資金曲線。
   - `--plot-equity <path.png>`：輸出資金曲線圖（需要 `matplotlib`）。
   - `--save-summary`：輸出回測摘要（含 win_rate、profit_factor、signal_count、avg_holding_minutes…）。
+  - `--out-dir <dir>`：指定報表輸出目錄（預設 `reports`）。
+  - `--format csv|json|both`：報表輸出格式（預設 `both`）。
 - **日期區間**：支援 `--start` / `--end`（如果你的 `ver14` 已套用該功能）或用環境變數（推薦）。
 
 **範例（回測 90 天 + 出資金曲線）**
 ```cmd
 python scripts\backtest_multi.py --cfg csp\configs\strategy.yaml --days 90 --fetch full ^
-  --export-equity-bars outputs\equity_90d.csv --plot-equity outputs\equity_90d.png --save-summary
+  --export-equity-bars outputs\equity_90d.csv --plot-equity outputs\equity_90d.png --save-summary --out-dir reports --format both
 ```
 
 **範例（指定 2025/07 全月，以環境變數方式）**
 ```cmd
 set START_DATE=2025-07-01
 set END_DATE=2025-07-31
-python scripts\backtest_multi.py --cfg csp\configs\strategy.yaml --save-summary
+python scripts\backtest_multi.py --cfg csp\configs\strategy.yaml --save-summary --out-dir reports --format both
 ```
 
 ---
@@ -231,7 +237,11 @@ python scripts\feature_optimize.py --cfg csp\configs\strategy.yaml --symbols BTC
 
 ## 輸出與檔案位置
 - **模型**：`io.models_dir`（按幣種分目錄，如 `models\BTCUSDT`）
-- **回測摘要**：啟用 `--save-summary` 後輸出到預設的輸出目錄（依專案實作而定）。
+- **回測摘要**：啟用 `--save-summary` 後輸出到 `--out-dir`（預設 `reports`），結構如下：
+  - `reports/{run_id}/summary_{symbol}.json`
+  - `reports/{run_id}/summary_{symbol}.csv`
+  - `reports/{run_id}/trades_{symbol}.csv`
+  - `reports/{run_id}/summary_all.json`
 - **資金曲線**：
   - `--export-equity-bars <csv>`：輸出欄位通常為 `timestamp,equity`
   - `--plot-equity <png>`：輸出資金曲線圖

--- a/csp/metrics/__init__.py
+++ b/csp/metrics/__init__.py
@@ -1,0 +1,6 @@
+"""Metrics utilities."""
+
+from .report import summarize
+
+__all__ = ["summarize"]
+

--- a/csp/metrics/report.py
+++ b/csp/metrics/report.py
@@ -1,0 +1,107 @@
+import numpy as np
+import pandas as pd
+from typing import Dict
+
+
+def summarize(equity_curve: pd.DataFrame, trades: pd.DataFrame, bar_seconds: int = 900) -> Dict[str, float]:
+    """Summarize backtest performance metrics.
+
+    Parameters
+    ----------
+    equity_curve : pd.DataFrame
+        DataFrame containing equity progression with at least ``equity_before`` and
+        ``equity_after`` columns. ``timestamp`` is optional but used for period
+        calculations.
+    trades : pd.DataFrame
+        Executed trade records with columns such as ``pnl`` and ``bars_held``.
+    bar_seconds : int, default 900
+        Number of seconds per bar. 15 minute bars correspond to 900 seconds.
+
+    Returns
+    -------
+    dict
+        Dictionary of performance metrics.
+    """
+    metrics = {
+        "total_return": 0.0,
+        "annual_return": 0.0,
+        "max_drawdown": 0.0,
+        "sharpe_ratio": 0.0,
+        "signal_count": 0,
+        "win_rate": 0.0,
+        "avg_win": 0.0,
+        "avg_loss": 0.0,
+        "profit_factor": 0.0,
+        "avg_holding_minutes": 0.0,
+        "exposure": 0.0,
+        "pnl_std": 0.0,
+    }
+
+    eq_df = equity_curve.copy() if isinstance(equity_curve, pd.DataFrame) else pd.DataFrame()
+    trades_df = trades.copy() if isinstance(trades, pd.DataFrame) else pd.DataFrame()
+
+    if eq_df.empty and trades_df.empty:
+        return metrics
+
+    # --- Total return ---
+    if not eq_df.empty:
+        initial_eq = float(eq_df.get("equity_before", pd.Series([1.0])).iloc[0])
+        final_eq = float(eq_df.get("equity_after", pd.Series([initial_eq])).iloc[-1])
+    else:
+        initial_eq = 1.0
+        final_eq = 1.0
+    total_return = (final_eq - initial_eq) / initial_eq if initial_eq != 0 else 0.0
+    metrics["total_return"] = float(total_return)
+
+    # Determine start/end time for annualization and exposure
+    start_time = end_time = None
+    if not trades_df.empty:
+        start_time = pd.to_datetime(trades_df["entry_time"]).min()
+        end_time = pd.to_datetime(trades_df["exit_time"]).max()
+    elif not eq_df.empty and "timestamp" in eq_df.columns:
+        start_time = pd.to_datetime(eq_df["timestamp"]).min()
+        end_time = pd.to_datetime(eq_df["timestamp"]).max()
+
+    # --- Annualized return ---
+    if start_time is not None and end_time is not None and end_time > start_time:
+        duration_seconds = (end_time - start_time).total_seconds()
+        years = duration_seconds / (365.25 * 24 * 3600)
+        if years > 0:
+            metrics["annual_return"] = float((1 + total_return) ** (1 / years) - 1)
+
+    # --- Max drawdown ---
+    if not eq_df.empty and "equity_after" in eq_df.columns:
+        equity = eq_df["equity_after"].astype(float)
+        running_max = equity.cummax()
+        drawdown = (equity / running_max) - 1.0
+        if not drawdown.empty:
+            metrics["max_drawdown"] = float(abs(drawdown.min()))
+
+    # --- Sharpe ratio (per bar) ---
+    if not eq_df.empty and len(eq_df) > 1 and "equity_after" in eq_df.columns:
+        returns = eq_df["equity_after"].pct_change().dropna()
+        if not returns.empty and returns.std() != 0:
+            periods_per_year = 365.25 * 24 * 3600 / float(bar_seconds)
+            metrics["sharpe_ratio"] = float(returns.mean() / returns.std() * np.sqrt(periods_per_year))
+
+    # --- Trade based metrics ---
+    if not trades_df.empty:
+        metrics["signal_count"] = int(len(trades_df))
+        wins = trades_df[trades_df["pnl"] > 0]["pnl"]
+        losses = trades_df[trades_df["pnl"] < 0]["pnl"]
+        metrics["win_rate"] = float(len(wins) / len(trades_df)) if len(trades_df) else 0.0
+        metrics["avg_win"] = float(wins.mean()) if len(wins) else 0.0
+        metrics["avg_loss"] = float(losses.mean()) if len(losses) else 0.0
+        loss_sum = float(losses.sum())
+        win_sum = float(wins.sum())
+        metrics["profit_factor"] = float(win_sum / abs(loss_sum)) if loss_sum != 0 else (float("inf") if win_sum > 0 else 0.0)
+        metrics["avg_holding_minutes"] = float(trades_df["bars_held"].mean() * (bar_seconds / 60.0)) if len(trades_df) else 0.0
+        metrics["pnl_std"] = float(trades_df["pnl"].std(ddof=0)) if len(trades_df) else 0.0
+
+        if start_time is not None and end_time is not None and end_time > start_time:
+            total_seconds = (end_time - start_time).total_seconds()
+            total_bars = total_seconds / float(bar_seconds)
+            held_bars = float(trades_df["bars_held"].sum())
+            metrics["exposure"] = float(held_bars / total_bars) if total_bars > 0 else 0.0
+
+    return metrics


### PR DESCRIPTION
## Summary
- expose `summarize` helper via `csp.metrics`
- document backtest summary options (`--save-summary`, `--out-dir`, `--format`) and output file structure in README

## Testing
- `pytest -q`
- `PYTHONPATH=. python scripts/backtest_multi.py --cfg csp/configs/strategy.yaml --days 30 --save-summary --out-dir reports --format both`


------
https://chatgpt.com/codex/tasks/task_e_68a870f13de4832d88e07fbe847ae945