### PR TITLE
Add multi-threshold classifier with labeling and training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,18 @@ python scripts\feature_optimize.py --cfg csp\configs\strategy.yaml --symbols BTC
 - **日誌**：`io.logs_dir`（例如 `logs\`）
 - **持倉狀態**：`io.position_file`（例如 `resources\current_position.yaml`）
 
+## 模型輸出結構與載入方式
+- 多 horizon × 多門檻訓練會在輸出目錄產生 `model_{h}_{t}.pkl` 與可選的 `cal_{h}_{t}.pkl`（校準器），以及 `meta.json`。
+- `meta.json` 包含訓練時使用的 `horizons`、`thresholds`、`feature_columns` 等資訊。
+- 載入範例：
+
+```python
+from csp.models.classifier_multi import MultiThresholdClassifier
+m = MultiThresholdClassifier.load("models/BTCUSDT/cls_multi")
+probs = m.predict_proba(df_features.tail(1))
+```
+
+
 ---
 
 ## 常見問題 FAQ

--- a/csp/configs/strategy.yaml
+++ b/csp/configs/strategy.yaml
@@ -15,6 +15,17 @@ io:
     interval: 15m
     limit: 96
     api_base: https://api.binance.com
+model:
+  type: "xgboost"
+  horizons: [2, 4, 8, 16, 48, 192]
+  thresholds: [0.2, 0.5, 1.0, 2.0]
+  calibrate: "isotonic"
+  cv:
+    type: "expanding"
+    n_splits: 5
+    purge_bars: 2
+    embargo_bars: 2
+  out_dir: "models/{SYMBOL}/cls_multi"
 features:
   default:
     ema_windows:

--- a/csp/data/labeling.py
+++ b/csp/data/labeling.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import pandas as pd
+
+
+def make_labels(df: pd.DataFrame, horizons: list[int], thresholds: list[float]) -> pd.DataFrame:
+    """Generate multi-horizon, multi-threshold binary labels.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Must contain a ``close`` column and be indexed by time.
+    horizons : list[int]
+        Number of future bars to look ahead for each horizon.
+    thresholds : list[float]
+        Thresholds in percent. 0.2 means future return >0.2%.
+
+    Returns
+    -------
+    DataFrame
+        Columns have MultiIndex (horizon, threshold) with values 0 or 1.
+        Last ``max(horizons)`` rows are dropped due to shift.
+    """
+    if "close" not in df.columns:
+        raise KeyError("DataFrame must contain 'close' column")
+
+    close = df["close"].astype(float)
+    labels = {}
+    for h in horizons:
+        future = close.shift(-h)
+        ret = (future / close - 1.0) * 100.0
+        for t in thresholds:
+            labels[(h, t)] = (ret > t).astype(int)
+    df_labels = pd.DataFrame(labels, index=df.index)
+    df_labels.columns = pd.MultiIndex.from_tuples(df_labels.columns, names=["horizon", "threshold"])
+    df_labels = df_labels.dropna()
+    return df_labels

--- a/csp/models/classifier_multi.py
+++ b/csp/models/classifier_multi.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Tuple, Optional, List
+import json
+import numpy as np
+import pandas as pd
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.model_selection import TimeSeriesSplit
+from sklearn.metrics import roc_auc_score
+from sklearn.base import clone
+import joblib
+import datetime
+
+
+@dataclass
+class MultiThresholdClassifier:
+    horizons: List[int]
+    thresholds: List[float]
+    model_type: str = "xgboost"
+    random_state: int = 42
+
+    models: Dict[Tuple[int, float], any] = field(default_factory=dict)
+    calibrators: Dict[Tuple[int, float], CalibratedClassifierCV] = field(default_factory=dict)
+    feature_columns: List[str] | None = None
+    cv_scores: Dict[str, float] = field(default_factory=dict)
+    skipped: List[Tuple[int, float]] = field(default_factory=list)
+    calibrate_method: str | None = None
+
+    # ------------------------------------------------------------------
+    def _build_model(self):
+        if self.model_type == "xgboost":
+            import xgboost as xgb
+            return xgb.XGBClassifier(
+                random_state=self.random_state,
+                use_label_encoder=False,
+                eval_metric="logloss",
+            )
+        elif self.model_type == "lightgbm":
+            import lightgbm as lgb
+            return lgb.LGBMClassifier(random_state=self.random_state)
+        elif self.model_type == "randomforest":
+            from sklearn.ensemble import RandomForestClassifier
+            return RandomForestClassifier(random_state=self.random_state)
+        else:
+            raise ValueError(f"Unsupported model_type: {self.model_type}")
+
+    # ------------------------------------------------------------------
+    def _time_series_cv(self, model, X: np.ndarray, y: pd.Series, cv_cfg: dict | None):
+        scores: List[float] = []
+        if not cv_cfg:
+            return scores
+        n_splits = int(cv_cfg.get("n_splits", 5))
+        cv_type = cv_cfg.get("type", "expanding")
+        purge = int(cv_cfg.get("purge_bars", 0))
+        embargo = int(cv_cfg.get("embargo_bars", 0))
+        n = len(X)
+        if n_splits < 2 or n <= n_splits:
+            return scores
+        if cv_type == "expanding":
+            tscv = TimeSeriesSplit(n_splits=n_splits)
+            for tr_idx, te_idx in tscv.split(X):
+                if y.iloc[tr_idx].nunique() < 2 or y.iloc[te_idx].nunique() < 2:
+                    continue
+                m = clone(model)
+                m.fit(X[tr_idx], y.iloc[tr_idx])
+                try:
+                    proba = m.predict_proba(X[te_idx])[:, 1]
+                    scores.append(roc_auc_score(y.iloc[te_idx], proba))
+                except Exception:
+                    continue
+        else:  # purged_kfold (simplified)
+            fold_sizes = np.full(n_splits, n // n_splits, dtype=int)
+            fold_sizes[: n % n_splits] += 1
+            current = 0
+            indices = np.arange(n)
+            for fold_size in fold_sizes:
+                start, stop = current, current + fold_size
+                te_idx = indices[start:stop]
+                tr_left = indices[: max(0, start - purge)]
+                tr_right = indices[min(n, stop + purge + embargo) :]
+                tr_idx = np.concatenate([tr_left, tr_right])
+                current = stop
+                if len(tr_idx) == 0 or len(te_idx) == 0:
+                    continue
+                if y.iloc[tr_idx].nunique() < 2 or y.iloc[te_idx].nunique() < 2:
+                    continue
+                m = clone(model)
+                m.fit(X[tr_idx], y.iloc[tr_idx])
+                try:
+                    proba = m.predict_proba(X[te_idx])[:, 1]
+                    scores.append(roc_auc_score(y.iloc[te_idx], proba))
+                except Exception:
+                    continue
+        return scores
+
+    # ------------------------------------------------------------------
+    def fit(
+        self,
+        df_features: pd.DataFrame,
+        df_labels: pd.DataFrame,
+        cv: dict | None = None,
+        calibrate: str | None = "isotonic",
+    ):
+        self.feature_columns = list(df_features.columns)
+        self.calibrate_method = calibrate
+        for h in self.horizons:
+            for t in self.thresholds:
+                col = (h, t)
+                if col not in df_labels.columns:
+                    self.skipped.append(col)
+                    continue
+                y = df_labels[col].dropna()
+                X = df_features.loc[y.index].values
+                if y.nunique() < 2 or len(y) < 20:
+                    self.skipped.append(col)
+                    continue
+                model = self._build_model()
+                scores = self._time_series_cv(model, X, y, cv)
+                if scores:
+                    self.cv_scores[f"{h}_{t}"] = float(np.mean(scores))
+                model_full = self._build_model()
+                model_full.fit(X, y)
+                self.models[col] = model_full
+                # calibration
+                method = calibrate
+                cal_obj = None
+                if calibrate:
+                    if len(y) < 50 or y.nunique() < 2:
+                        if method == "isotonic":
+                            method = "platt"
+                        else:
+                            method = None
+                    if method:
+                        cv_method = "sigmoid" if method == "platt" else "isotonic"
+                        try:
+                            cal_obj = CalibratedClassifierCV(
+                                model_full, method=cv_method, cv=3
+                            )
+                            cal_obj.fit(X, y)
+                        except Exception:
+                            cal_obj = None
+                if cal_obj:
+                    self.calibrators[col] = cal_obj
+        return self
+
+    # ------------------------------------------------------------------
+    def predict_proba(self, df_features_latest: pd.DataFrame) -> Dict[Tuple[int, float], float]:
+        if self.feature_columns is None:
+            raise ValueError("Model not fitted")
+        X = df_features_latest[self.feature_columns].values
+        out: Dict[Tuple[int, float], float] = {}
+        for key, model in self.models.items():
+            if key in self.calibrators:
+                proba = self.calibrators[key].predict_proba(X)[:, 1]
+            else:
+                proba = model.predict_proba(X)[:, 1]
+            out[key] = float(proba[-1])
+        for key in self.skipped:
+            if key not in out:
+                out[key] = float("nan")
+        return out
+
+    # ------------------------------------------------------------------
+    def save(self, out_dir: str) -> None:
+        path = Path(out_dir)
+        path.mkdir(parents=True, exist_ok=True)
+        for (h, t), model in self.models.items():
+            joblib.dump(model, path / f"model_{h}_{t}.pkl")
+            cal = self.calibrators.get((h, t))
+            if cal is not None:
+                joblib.dump(cal, path / f"cal_{h}_{t}.pkl")
+        meta = {
+            "horizons": self.horizons,
+            "thresholds": self.thresholds,
+            "model_type": self.model_type,
+            "feature_columns": self.feature_columns,
+            "trained_at": datetime.datetime.utcnow().isoformat(),
+            "cv_scores": self.cv_scores,
+            "skipped": self.skipped,
+            "calibrate": self.calibrate_method,
+        }
+        with open(path / "meta.json", "w", encoding="utf-8") as f:
+            json.dump(meta, f, ensure_ascii=False, indent=2)
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def load(cls, in_dir: str) -> "MultiThresholdClassifier":
+        path = Path(in_dir)
+        meta = json.load(open(path / "meta.json", "r", encoding="utf-8"))
+        obj = cls(
+            horizons=meta.get("horizons", []),
+            thresholds=meta.get("thresholds", []),
+            model_type=meta.get("model_type", "xgboost"),
+            random_state=meta.get("random_state", 42),
+        )
+        obj.feature_columns = meta.get("feature_columns")
+        obj.cv_scores = meta.get("cv_scores", {})
+        obj.skipped = [tuple(x) for x in meta.get("skipped", [])]
+        obj.calibrate_method = meta.get("calibrate")
+        for h in obj.horizons:
+            for t in obj.thresholds:
+                key = (h, t)
+                model_path = path / f"model_{h}_{t}.pkl"
+                if model_path.exists():
+                    obj.models[key] = joblib.load(model_path)
+                cal_path = path / f"cal_{h}_{t}.pkl"
+                if cal_path.exists():
+                    obj.calibrators[key] = joblib.load(cal_path)
+        return obj

--- a/scripts/train_multi_cls.py
+++ b/scripts/train_multi_cls.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+import argparse
+from pathlib import Path
+import json
+import yaml
+import pandas as pd
+from csp.features.h16 import build_features_15m_4h
+from csp.data.labeling import make_labels
+from csp.models.classifier_multi import MultiThresholdClassifier
+from csp.utils.config import get_symbol_features
+
+
+def load_csv(csv_path: str, days: int | None = None) -> pd.DataFrame:
+    df = pd.read_csv(csv_path)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    df = df.set_index("timestamp").sort_index()
+    if days is not None:
+        limit = days * 24 * 60 // 15
+        df = df.iloc[-limit:]
+    return df
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cfg", default="csp/configs/strategy.yaml")
+    ap.add_argument("--days", type=int, default=None)
+    args = ap.parse_args()
+
+    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    csv_map = cfg["io"]["csv_paths"]
+    model_cfg = cfg.get("model", {})
+    horizons = model_cfg.get("horizons", [16])
+    thresholds = model_cfg.get("thresholds", [0.0])
+    model_type = model_cfg.get("type", "xgboost")
+    calibrate = model_cfg.get("calibrate", "isotonic")
+    cv_cfg = model_cfg.get("cv")
+    out_dir_tpl = model_cfg.get("out_dir", "models/{SYMBOL}/cls_multi")
+
+    for sym in cfg.get("symbols", []):
+        csv_path = csv_map.get(sym)
+        if not csv_path:
+            print(f"[SKIP] {sym}: no csv path")
+            continue
+        print(f"[LOAD] {sym} from {csv_path}")
+        df_raw = load_csv(csv_path, args.days)
+        feat_params = get_symbol_features(cfg, sym)
+        feats = build_features_15m_4h(
+            df_raw.reset_index(),
+            ema_windows=tuple(feat_params["ema_windows"]),
+            rsi_window=feat_params["rsi_window"],
+            bb_window=feat_params["bb_window"],
+            bb_std=feat_params["bb_std"],
+            atr_window=feat_params["atr_window"],
+            h4_resample=feat_params["h4_resample"],
+        )
+        df_labels = make_labels(feats, horizons, thresholds)
+        feats = feats.loc[df_labels.index]
+        feature_cols = [
+            c for c in feats.columns if c not in ["timestamp", "open", "high", "low", "close", "volume"]
+        ]
+        X = feats[feature_cols]
+        clf = MultiThresholdClassifier(horizons, thresholds, model_type=model_type)
+        clf.fit(X, df_labels, cv=cv_cfg, calibrate=calibrate)
+        out_dir = Path(out_dir_tpl.replace("{SYMBOL}", sym))
+        clf.save(str(out_dir))
+        print(f"[SAVED] {sym} -> {out_dir}")


### PR DESCRIPTION
## Summary
- add `MultiThresholdClassifier` to handle multiple horizons and thresholds with calibration and CV
- provide `make_labels` utility for multi-horizon percentage-threshold labels
- introduce `train_multi_cls.py` and update config/docs for new model output structure

## Testing
- `PYTHONPATH=. python scripts/train_multi_cls.py --cfg csp/configs/strategy.yaml --days 30`
- `python - <<'PY'
from csp.models.classifier_multi import MultiThresholdClassifier
import pandas as pd, json
m = MultiThresholdClassifier.load('models/BTCUSDT/cls_multi')
feat_cols = json.load(open('models/BTCUSDT/cls_multi/meta.json'))['feature_columns']
x = pd.DataFrame([[0]*len(feat_cols)], columns=feat_cols)
print(m.predict_proba(x))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89bc15734832db4e351c76a940f5f