### PR TITLE
fix: correct invalid workflow permission

### DIFF
--- a/.github/workflows/devlog_sync.yml
+++ b/.github/workflows/devlog_sync.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: write
   issues: write
-  projects: write
+  repository-projects: write
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary
- replace invalid `projects` permission with `repository-projects` in devlog sync workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a93c52af6c832d99a5fa7989d35606