### PR TITLE
feat: extend feature set and wire through training and realtime

### DIFF
--- a/csp/backtesting/backtest_v2.py
+++ b/csp/backtesting/backtest_v2.py
@@ -11,6 +11,7 @@ import joblib
 
 from csp.data.loader import load_15m_csv
 from csp.features.h16 import build_features_15m_4h
+from csp.core.feature import add_features
 from csp.utils.config import get_symbol_features
 
 @dataclass
@@ -172,6 +173,14 @@ def run_backtest_for_symbol(csv_path: str, cfg_path: str, symbol: Optional[str] 
         bb_std=feat_params["bb_std"],
         atr_window=feat_params["atr_window"],
         h4_resample=feat_params["h4_resample"],
+    )
+    feats = add_features(
+        feats,
+        prev_high_period=feat_params["prev_high_period"],
+        prev_low_period=feat_params["prev_low_period"],
+        bb_window=feat_params["bb_window"],
+        atr_window=feat_params["atr_window"],
+        atr_percentile_window=feat_params["atr_percentile_window"],
     )
     bundle = _load_model_bundle(cfg, sym)
     model = bundle["model"]

--- a/csp/configs/strategy.yaml
+++ b/csp/configs/strategy.yaml
@@ -31,6 +31,11 @@ model:
     embargo_bars: 2
   out_dir: "models/{SYMBOL}/cls_multi"
 features:
+  prev_high_period: 20
+  prev_low_period: 20
+  bb_window: 24
+  atr_window: 14
+  atr_percentile_window: 100
   default:
     ema_windows:
     - 9

--- a/csp/core/__init__.py
+++ b/csp/core/__init__.py
@@ -1,0 +1,3 @@
+from .feature import add_features
+
+__all__ = ["add_features"]

--- a/csp/core/feature.py
+++ b/csp/core/feature.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _rolling_percentile(series: pd.Series, window: int) -> pd.Series:
+    """Return percentile rank of the last value within a rolling window."""
+
+    def percentile_of_last(values: np.ndarray) -> float:
+        arr = np.sort(values)
+        # percentile rank (0-1) of the last element
+        return np.searchsorted(arr, values[-1], side="right") / len(arr)
+
+    return series.rolling(window).apply(percentile_of_last, raw=True)
+
+
+def add_features(
+    df: pd.DataFrame,
+    *,
+    prev_high_period: int = 20,
+    prev_low_period: int = 20,
+    bb_window: int = 20,
+    atr_window: int = 14,
+    atr_percentile_window: int = 100,
+) -> pd.DataFrame:
+    """Add additional technical features required by classifiers.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Must contain columns ``open``, ``high``, ``low``, ``close`` and ``volume``.
+    prev_high_period, prev_low_period : int
+        Lookback periods for previous high/low distance features.
+    bb_window : int
+        Window for Bollinger Bands if not already present.
+    atr_window : int
+        Window for ATR calculation.
+    atr_percentile_window : int
+        Lookback for ATR percentile rank.
+    """
+    out = df.copy()
+
+    # Previous high/low distance
+    rolling_high = out["high"].rolling(prev_high_period).max()
+    rolling_low = out["low"].rolling(prev_low_period).min()
+    out["prev_high_dist"] = (out["high"] - rolling_high) / rolling_high
+    out["prev_low_dist"] = (out["low"] - rolling_low) / rolling_low
+
+    # Candle shape
+    out["candle_body"] = out["close"] - out["open"]
+    out["candle_upper"] = out["high"] - out[["open", "close"]].max(axis=1)
+    out["candle_lower"] = out[["open", "close"]].min(axis=1) - out["low"]
+
+    body = out["candle_body"]
+    prev_body = body.shift(1)
+    curr_high_body = out[["open", "close"]].max(axis=1)
+    curr_low_body = out[["open", "close"]].min(axis=1)
+    prev_high_body = out[["open", "close"]].shift(1).max(axis=1)
+    prev_low_body = out[["open", "close"]].shift(1).min(axis=1)
+
+    engulf_long = (
+        (body.abs() > prev_body.abs())
+        & (curr_low_body <= prev_low_body)
+        & (curr_high_body >= prev_high_body)
+        & (body > 0)
+        & (prev_body < 0)
+    )
+    engulf_short = (
+        (body.abs() > prev_body.abs())
+        & (curr_low_body <= prev_low_body)
+        & (curr_high_body >= prev_high_body)
+        & (body < 0)
+        & (prev_body > 0)
+    )
+    engulf = pd.Series(0, index=out.index, dtype=int)
+    engulf[engulf_long] = 1
+    engulf[engulf_short] = -1
+    out["candle_engulfing"] = engulf
+
+    # Bollinger Band width
+    if {"bb_high", "bb_low", "bb_mid"}.issubset(out.columns):
+        upper = out["bb_high"]
+        lower = out["bb_low"]
+        mid = out["bb_mid"]
+    else:
+        m = out["close"].rolling(bb_window).mean()
+        s = out["close"].rolling(bb_window).std()
+        mid = m
+        upper = m + 2 * s
+        lower = m - 2 * s
+    out["bb_width"] = (upper - lower) / mid
+
+    # VWAP deviation
+    typical_price = (out["high"] + out["low"] + out["close"]) / 3
+    cum_vol = out["volume"].cumsum()
+    cum_vp = (typical_price * out["volume"]).cumsum()
+    vwap = cum_vp / cum_vol.replace(0, np.nan)
+    out["vwap_dev"] = (out["close"] - vwap) / vwap
+
+    # ATR and its percentile
+    h = out["high"]
+    l = out["low"]
+    c = out["close"]
+    prev_c = c.shift(1)
+    tr = pd.concat([(h - l).abs(), (h - prev_c).abs(), (l - prev_c).abs()], axis=1).max(axis=1)
+    atr = tr.rolling(atr_window).mean()
+    out["atr_percentile"] = _rolling_percentile(atr, atr_percentile_window)
+
+    out = out.dropna().reset_index(drop=True)
+    return out

--- a/csp/diagnostics/proba_diag.py
+++ b/csp/diagnostics/proba_diag.py
@@ -9,6 +9,7 @@ import numpy as np
 import xgboost as xgb
 
 from csp.features.h16 import build_features_15m_4h
+from csp.core.feature import add_features
 from csp.utils.config import get_symbol_features
 
 
@@ -73,6 +74,14 @@ def build_features(df, horizon: int, feat_params: Dict[str, Any]):
         bb_std=feat_params["bb_std"],
         atr_window=feat_params["atr_window"],
         h4_resample=feat_params["h4_resample"],
+    )
+    feats = add_features(
+        feats,
+        prev_high_period=feat_params["prev_high_period"],
+        prev_low_period=feat_params["prev_low_period"],
+        bb_window=feat_params["bb_window"],
+        atr_window=feat_params["atr_window"],
+        atr_percentile_window=feat_params["atr_percentile_window"],
     )
     return feats, list(feats.columns)
 

--- a/csp/models/train_h16_dynamic.py
+++ b/csp/models/train_h16_dynamic.py
@@ -140,6 +140,7 @@ def train(input_data: Union[pd.DataFrame, str, Path], cfg: dict, *, date_args: d
     import joblib
     import xgboost as xgb
     from csp.features.h16 import build_features_15m_4h, make_labels
+    from csp.core.feature import add_features
     from csp.utils.config import get_symbol_features
 
     # 若提供路徑字串，嘗試推斷 symbol 名稱
@@ -163,6 +164,14 @@ def train(input_data: Union[pd.DataFrame, str, Path], cfg: dict, *, date_args: d
         bb_std=feat_params["bb_std"],
         atr_window=feat_params["atr_window"],
         h4_resample=feat_params["h4_resample"],
+    )
+    feats = add_features(
+        feats,
+        prev_high_period=feat_params["prev_high_period"],
+        prev_low_period=feat_params["prev_low_period"],
+        bb_window=feat_params["bb_window"],
+        atr_window=feat_params["atr_window"],
+        atr_percentile_window=feat_params["atr_percentile_window"],
     )
 
     # 建立標籤並對齊

--- a/csp/optimize/evaluator.py
+++ b/csp/optimize/evaluator.py
@@ -31,6 +31,9 @@ def walk_forward_evaluate(cfg_path: str, symbol: str,
     sym_cfg["bollinger"]["window"] = int(feature_params["bb_window"])
     sym_cfg["bollinger"]["std"] = float(feature_params["bb_std"])
     sym_cfg["atr"]["window"] = int(feature_params["atr_window"])
+    sym_cfg["prev_high_period"] = int(feature_params.get("prev_high_period", 20))
+    sym_cfg["prev_low_period"] = int(feature_params.get("prev_low_period", 20))
+    sym_cfg["atr_percentile_window"] = int(feature_params.get("atr_percentile_window", 100))
     # base parameters
     default["ema_windows"] = feature_params.get("ema_windows", default.get("ema_windows", (9, 21, 50)))
     h4_rule = default.setdefault("h4_rule", {})

--- a/csp/optimize/feature_opt.py
+++ b/csp/optimize/feature_opt.py
@@ -25,6 +25,9 @@ def _suggest_params(trial: optuna.Trial) -> Dict:
         "bb_window": trial.suggest_int("bb_window", 10, 40),
         "bb_std": trial.suggest_float("bb_std", 1.0, 3.5),
         "atr_window": trial.suggest_int("atr_window", 7, 40),
+        "prev_high_period": trial.suggest_int("prev_high_period", 5, 60),
+        "prev_low_period": trial.suggest_int("prev_low_period", 5, 60),
+        "atr_percentile_window": trial.suggest_int("atr_percentile_window", 50, 200),
     }
 
 
@@ -105,6 +108,9 @@ def apply_best_params_to_cfg(cfg_path: str, symbol: str, best_params: Dict[str, 
         "std": float(best_params["bb_std"]),
     })
     sym_cfg["atr"].update({"enabled": True, "window": int(best_params["atr_window"])})
+    sym_cfg["prev_high_period"] = int(best_params.get("prev_high_period", 20))
+    sym_cfg["prev_low_period"] = int(best_params.get("prev_low_period", 20))
+    sym_cfg["atr_percentile_window"] = int(best_params.get("atr_percentile_window", 100))
 
     old_text = cfg_path.read_text(encoding="utf-8")
     new_text = yaml.dump(cfg, allow_unicode=True, sort_keys=False)

--- a/csp/optimize/featurizer.py
+++ b/csp/optimize/featurizer.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 import pandas as pd
 
 from csp.features.h16 import build_features_15m_4h
+from csp.core.feature import add_features as _add_extra_features
 
 
 def default_params() -> Dict[str, Any]:
@@ -12,6 +13,9 @@ def default_params() -> Dict[str, Any]:
         "bb_window": 20,
         "bb_std": 2.0,
         "atr_window": 14,
+        "prev_high_period": 20,
+        "prev_low_period": 20,
+        "atr_percentile_window": 100,
         "h4_resample": "4H",
     }
 
@@ -33,5 +37,13 @@ def add_features(df: pd.DataFrame, params: Dict[str, Any] | None = None) -> pd.D
         bb_std=float(p["bb_std"]),
         atr_window=int(p["atr_window"]),
         h4_resample=p.get("h4_resample", "4H"),
+    )
+    feats = _add_extra_features(
+        feats,
+        prev_high_period=int(p["prev_high_period"]),
+        prev_low_period=int(p["prev_low_period"]),
+        bb_window=int(p["bb_window"]),
+        atr_window=int(p["atr_window"]),
+        atr_percentile_window=int(p["atr_percentile_window"]),
     )
     return feats

--- a/csp/pipeline/realtime_v2.py
+++ b/csp/pipeline/realtime_v2.py
@@ -22,6 +22,7 @@ from dateutil import tz
 
 from csp.data.loader import load_15m_csv
 from csp.features.h16 import build_features_15m_4h
+from csp.core.feature import add_features
 from csp.utils.config import get_symbol_features
 from csp.utils.logger import get_logger
 
@@ -172,6 +173,14 @@ def run_once(csv_path: str, cfg_path: str, *, debug: bool | None = None) -> Dict
         bb_std=feat_params["bb_std"],
         atr_window=feat_params["atr_window"],
         h4_resample=feat_params["h4_resample"],
+    )
+    feats = add_features(
+        feats,
+        prev_high_period=feat_params["prev_high_period"],
+        prev_low_period=feat_params["prev_low_period"],
+        bb_window=feat_params["bb_window"],
+        atr_window=feat_params["atr_window"],
+        atr_percentile_window=feat_params["atr_percentile_window"],
     )
 
     bundle = _load_model_bundle(cfg, sym)

--- a/csp/strategy/aggregator.py
+++ b/csp/strategy/aggregator.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from csp.models.classifier_multi import MultiThresholdClassifier
 from csp.features.h16 import build_features_15m_4h
+from csp.core.feature import add_features
 from csp.utils.config import get_symbol_features
 
 
@@ -148,6 +149,14 @@ def get_latest_signal(symbol: str, cfg: Dict[str, Any]) -> Optional[Dict[str, An
             bb_std=feat_params["bb_std"],
             atr_window=feat_params["atr_window"],
             h4_resample=feat_params.get("h4_resample", "4H"),
+        )
+        feats = add_features(
+            feats,
+            prev_high_period=feat_params["prev_high_period"],
+            prev_low_period=feat_params["prev_low_period"],
+            bb_window=feat_params["bb_window"],
+            atr_window=feat_params["atr_window"],
+            atr_percentile_window=feat_params["atr_percentile_window"],
         )
         latest = feats.tail(1)
         if latest.empty:

--- a/csp/utils/config.py
+++ b/csp/utils/config.py
@@ -45,10 +45,27 @@ def get_symbol_features(cfg: Dict[str, Any], symbol: str) -> Dict[str, Any]:
     boll = merge("bollinger")
     atr = merge("atr")
 
+    bb_window_base = int(boll.get("window", 20))
+    atr_window_base = int(atr.get("window", 14))
+    bb_window = int(feats.get("bb_window", bb_window_base))
+    atr_window = int(feats.get("atr_window", atr_window_base))
+    bb_window = int(per_sym.get("bb_window", bb_window))
+    atr_window = int(per_sym.get("atr_window", atr_window))
+
+    prev_high_period = int(feats.get("prev_high_period", 20))
+    prev_low_period = int(feats.get("prev_low_period", 20))
+    atr_pct_window = int(feats.get("atr_percentile_window", 100))
+    prev_high_period = int(per_sym.get("prev_high_period", prev_high_period))
+    prev_low_period = int(per_sym.get("prev_low_period", prev_low_period))
+    atr_pct_window = int(per_sym.get("atr_percentile_window", atr_pct_window))
+
     out.update({
         "rsi_window": int(rsi.get("window", 14)),
-        "bb_window": int(boll.get("window", 20)),
+        "bb_window": bb_window,
         "bb_std": float(boll.get("std", 2.0)),
-        "atr_window": int(atr.get("window", 14)),
+        "atr_window": atr_window,
+        "prev_high_period": prev_high_period,
+        "prev_low_period": prev_low_period,
+        "atr_percentile_window": atr_pct_window,
     })
     return out

--- a/scripts/train_multi_cls.py
+++ b/scripts/train_multi_cls.py
@@ -5,6 +5,7 @@ import json
 import yaml
 import pandas as pd
 from csp.features.h16 import build_features_15m_4h
+from csp.core.feature import add_features
 from csp.data.labeling import make_labels
 from csp.models.classifier_multi import MultiThresholdClassifier
 from csp.utils.config import get_symbol_features
@@ -52,6 +53,14 @@ if __name__ == "__main__":
             bb_std=feat_params["bb_std"],
             atr_window=feat_params["atr_window"],
             h4_resample=feat_params["h4_resample"],
+        )
+        feats = add_features(
+            feats,
+            prev_high_period=feat_params["prev_high_period"],
+            prev_low_period=feat_params["prev_low_period"],
+            bb_window=feat_params["bb_window"],
+            atr_window=feat_params["atr_window"],
+            atr_percentile_window=feat_params["atr_percentile_window"],
         )
         df_labels = make_labels(feats, horizons, thresholds)
         feats = feats.loc[df_labels.index]


### PR DESCRIPTION
## Summary
- add `csp.core.add_features` with distance, candle, Bollinger width, VWAP deviation and ATR percentile metrics
- expose new feature parameters in strategy config and optimization search space
- integrate new features across training, backtesting and realtime pipelines

## Testing
- `python - <<'PY'
import pandas as pd
from csp.core.feature import add_features

df = pd.DataFrame({
    "open":[100,101,102],
    "high":[103,104,105],
    "low":[99,100,101],
    "close":[102,103,104],
    "volume":[10,12,15]
})
print(add_features(df).columns)
PY`
- `PYTHONPATH=. python scripts/train_multi_cls.py --cfg csp/configs/strategy.yaml --days=10`

------
https://chatgpt.com/codex/tasks/task_e_68a982a7bdc8832d8aee78795a97484d