### PR TITLE
Add realtime loop runner script

### DIFF
--- a/run_realtime.sh
+++ b/run_realtime.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /opt/crypto_strategy_project
+
+if [ -f ".venv/bin/activate" ]; then
+  source .venv/bin/activate
+fi
+
+echo "$(date) Start realtime loop..."
+exec python scripts/realtime_loop.py --cfg csp/configs/strategy.yaml --delay-sec 15


### PR DESCRIPTION
## Summary
- add run_realtime.sh to launch realtime loop with optional venv

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa0ab2c818832d9211d8565ae4d317