### PR TITLE
fix: normalize cfg handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ realtime:
 python scripts\train_multi.py --cfg csp\configs\strategy.yaml
 ```
 - 預設會從設定檔載入每個幣種的 CSV，並將模型輸出到 `io.models_dir`（每幣一個子資料夾）。
+- 所有腳本會透過 `csp.utils.io.load_cfg` 讀取設定，無論傳入的是檔案路徑或已解析的 `dict`。
 
 ### 回測（多幣）
 ```cmd

--- a/csp/backtesting/backtest_v2.py
+++ b/csp/backtesting/backtest_v2.py
@@ -5,9 +5,9 @@ from pathlib import Path
 import json
 import numpy as np
 import pandas as pd
-import yaml
 import xgboost as xgb
 import joblib
+from csp.utils.io import load_cfg
 
 from csp.data.loader import load_15m_csv
 from csp.features.h16 import build_features_15m_4h
@@ -24,9 +24,6 @@ class EntryZoneCfg:
     lookahead_bars: int = 16
     long_x: float = 0.5
     short_x: float = 0.5
-
-def _load_cfg(cfg_path: str) -> Dict[str, Any]:
-    return yaml.safe_load(open(cfg_path, "r", encoding="utf-8"))
 
 def _load_model_bundle(cfg: Dict[str, Any], symbol: str):
     mdir = Path(cfg["io"]["models_dir"]) / symbol
@@ -108,9 +105,10 @@ def _apply_exit(bar: pd.Series, side: str, tp: float, sl: float) -> Optional[str
         if low  <= tp: return "tp"
     return None
 
-def run_backtest_for_symbol(csv_path: str, cfg_path: str, symbol: Optional[str] = None,
+def run_backtest_for_symbol(csv_path: str, cfg: Dict[str, Any] | str, symbol: Optional[str] = None,
                             start_ts: Optional[pd.Timestamp] = None, end_ts: Optional[pd.Timestamp] = None) -> Dict[str, Any]:
-    cfg = _load_cfg(cfg_path)
+    cfg = load_cfg(cfg)
+    assert isinstance(cfg, dict), f"cfg must be dict, got {type(cfg)}"
     sym = symbol or _infer_symbol_from_path(csv_path)
     feat_params = get_symbol_features(cfg, sym)
     long_thr  = float(cfg["execution"]["long_prob_threshold"])

--- a/csp/diagnostics/proba_diag.py
+++ b/csp/diagnostics/proba_diag.py
@@ -14,6 +14,7 @@ from csp.utils.config import get_symbol_features
 
 
 def load_io_from_cfg(cfg: Dict[str, Any], symbol: str) -> Dict[str, Any]:
+    assert isinstance(cfg, dict), f"cfg must be dict, got {type(cfg)}"
     csv_path = cfg.get("io", {}).get("csv_paths", {}).get(symbol)
     models_root = Path(cfg.get("io", {}).get("models_dir", "models")) / symbol
     feat_params = get_symbol_features(cfg, symbol)

--- a/csp/models/train_h16_dynamic.py
+++ b/csp/models/train_h16_dynamic.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Union, Tuple, Optional, Dict
 
 import pandas as pd
+from csp.utils.io import load_cfg
 
 try:
     from csp.utils.dates import resolve_time_range_like, slice_by_utc
@@ -115,6 +116,8 @@ def train(input_data: Union[pd.DataFrame, str, Path], cfg: dict, *, date_args: d
     - 也可傳 **kwargs: start=..., end=..., days=...
     備註：這裡只負責「資料讀取 + 日期區間 + warmup」，後續特徵/訓練保持你原本的流程。
     """
+    cfg = load_cfg(cfg)
+    assert isinstance(cfg, dict), f"cfg must be dict, got {type(cfg)}"
     # 1) 讀資料
     if isinstance(input_data, (str, Path)):
         df = _read_csv_smart(input_data)
@@ -131,6 +134,7 @@ def train(input_data: Union[pd.DataFrame, str, Path], cfg: dict, *, date_args: d
         df2, utc_start, utc_end = _apply_date_range(df, dargs)
     else:
         df2, utc_start, utc_end = df, None, None
+    df2 = df2.reset_index().rename_axis(None)
 
     # 4) ==== 特徵 / 標籤 / 模型訓練 ====
     import json

--- a/csp/runtime/exit_watchdog.py
+++ b/csp/runtime/exit_watchdog.py
@@ -9,6 +9,7 @@ from dateutil import parser as dateparser
 
 from csp.utils.notifier import notify_trade_close
 from csp.strategy.aggregator import get_latest_signal
+from csp.utils.io import load_cfg
 
 
 def _load_position(path: str) -> Dict[str, Any] | None:
@@ -46,12 +47,14 @@ def _append_trade(log_path: Path, trade: Dict[str, Any]):
         f.write(line + "\n")
 
 
-def check_exit_once(cfg: Dict[str, Any], latest_price: float, now_ts: datetime, dry_run: bool = False) -> Dict[str, Any]:
+def check_exit_once(cfg: Dict[str, Any] | str, latest_price: float, now_ts: datetime, dry_run: bool = False) -> Dict[str, Any]:
     """
     依序檢查 TP、SL、時間止損、模型翻向。
     若觸發則平倉、記錄交易、清除 position、通知。
     回傳 dict 包含 action (hold|close)、reason、pnl、position。
     """
+    cfg = load_cfg(cfg)
+    assert isinstance(cfg, dict), f"cfg must be dict, got {type(cfg)}"
     io_cfg = cfg.get("io", {})
     pos_file = io_cfg.get("position_file")
     if not pos_file:

--- a/csp/strategy/aggregator.py
+++ b/csp/strategy/aggregator.py
@@ -145,6 +145,7 @@ def get_latest_signal(symbol: str, cfg: dict, fresh_min: float = 5.0) -> Optiona
 
     from csp.core.feature import add_features  # local import to keep dependency light
 
+    assert isinstance(cfg, dict), f"cfg must be dict, got {type(cfg)}"
     try:
         from csp.models.classifier_multi import MultiThresholdClassifier
     except Exception:

--- a/csp/utils/config.py
+++ b/csp/utils/config.py
@@ -22,6 +22,7 @@ def get_symbol_features(cfg: Dict[str, Any], symbol: str) -> Dict[str, Any]:
     is flattened to match the historical ``feature`` parameters used by the
     feature builders.
     """
+    assert isinstance(cfg, dict), f"cfg must be dict, got {type(cfg)}"
     feats = cfg.get("features", {})
     default = feats.get("default", {})
     per_sym = feats.get("per_symbol", {}).get(symbol, {})

--- a/csp/utils/io.py
+++ b/csp/utils/io.py
@@ -1,0 +1,17 @@
+import os
+import yaml
+
+
+def load_cfg(cfg_or_path):
+    """
+    接受 YAML 路徑 (str) 或 dict，最後一律回傳 dict。
+    用於所有 train/backtest/realtime 腳本與內部 train() 等入口。
+    """
+    if isinstance(cfg_or_path, dict):
+        return cfg_or_path
+    if isinstance(cfg_or_path, str) and os.path.exists(cfg_or_path):
+        with open(cfg_or_path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    raise ValueError(
+        f"Invalid cfg input (expect dict or existing path): {type(cfg_or_path)} -> {cfg_or_path}"
+    )

--- a/scripts/backtest_multi.py
+++ b/scripts/backtest_multi.py
@@ -10,16 +10,13 @@ from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 import requests
-import yaml
 
 # 依賴 backtest_v2 的核心邏輯
 from csp.backtesting.backtest_v2 import run_backtest_for_symbol
 from csp.metrics.report import summarize
+from csp.utils.io import load_cfg
 
 BINANCE_BASE = "https://api.binance.com"
-
-def load_cfg(path: str) -> dict:
-    return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
 
 def to_utc(dt: datetime) -> datetime:
     if dt.tzinfo is None:

--- a/scripts/diag_proba.py
+++ b/scripts/diag_proba.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import pandas as pd
-import yaml
 
 from csp.diagnostics import proba_diag
 from csp.data.loader import load_15m_csv
 from csp.pipeline.realtime_v2 import initialize_history
+from csp.utils.io import load_cfg
 
 
 def parse_args() -> argparse.Namespace:
@@ -24,7 +24,7 @@ def parse_args() -> argparse.Namespace:
 
 def main():
     args = parse_args()
-    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    cfg = load_cfg(args.cfg)
 
     if args.all:
         symbols = cfg.get("symbols", [])

--- a/scripts/diag_signal.py
+++ b/scripts/diag_signal.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 import pandas as pd
 import pytz
+from csp.utils.io import load_cfg
 
 
 def _fmt_ts(ts_utc):
@@ -30,9 +31,7 @@ def main():
     )
     args = ap.parse_args()
 
-    import yaml
-
-    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    cfg = load_cfg(args.cfg)
     from csp.core.feature import add_features  # type: ignore
     from csp.strategy.aggregator import aggregate_signal
     try:

--- a/scripts/exit_watchdog.py
+++ b/scripts/exit_watchdog.py
@@ -5,10 +5,11 @@ import time
 from datetime import datetime
 
 import requests
-import yaml
 from dateutil import tz
+import yaml
 
 from csp.runtime.exit_watchdog import check_exit_once
+from csp.utils.io import load_cfg
 
 TW = tz.gettz("Asia/Taipei")
 
@@ -28,7 +29,7 @@ def main():
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
-    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    cfg = load_cfg(args.cfg)
     pos_file = cfg.get("io", {}).get("position_file")
     if not pos_file:
         print("No position_file in config")

--- a/scripts/feature_optimize.py
+++ b/scripts/feature_optimize.py
@@ -5,11 +5,11 @@ import sys
 from pathlib import Path
 
 import pandas as pd
-import yaml
 
 from csp.data.loader import load_15m_csv
 from csp.utils.dates import resolve_time_range_like
 from csp.optimize.feature_opt import optimize_symbol, apply_best_params_to_cfg
+from csp.utils.io import load_cfg
 
 
 def _read_date_args_from_env() -> dict:
@@ -34,7 +34,7 @@ def main() -> None:
     ap.add_argument("--apply-to-cfg", action="store_true", help="將最佳參數寫回 cfg")
     args = ap.parse_args()
 
-    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    cfg = load_cfg(args.cfg)
     if args.symbols:
         symbols = [s.strip() for s in args.symbols.split(',') if s.strip()]
     else:

--- a/scripts/fetch_csv.py
+++ b/scripts/fetch_csv.py
@@ -2,9 +2,9 @@
 import argparse, json
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-import yaml
 
 from csp.data.binance import fetch_to_csv
+from csp.utils.io import load_cfg
 
 def main():
     ap = argparse.ArgumentParser()
@@ -15,7 +15,7 @@ def main():
     ap.add_argument("--end", help="UTC end time ISO8601, default now")
     args = ap.parse_args()
 
-    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    cfg = load_cfg(args.cfg)
     symbols = args.symbols or cfg.get("symbols") or [cfg["symbol"]]
     csv_paths = cfg.get("io", {}).get("csv_paths", {})
     interval = cfg.get("bar_interval", "15m")

--- a/scripts/predict_and_notify.py
+++ b/scripts/predict_and_notify.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 import argparse
 import json
-import yaml
 
 from csp.pipeline.realtime_v2 import run_once
 from csp.utils.notifier import notify
+from csp.utils.io import load_cfg
 
 
 def main():
@@ -14,8 +14,8 @@ def main():
     ap.add_argument("--debug", action="store_true")
     args = ap.parse_args()
 
-    res = run_once(args.csv, args.cfg, debug=args.debug)
-    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    cfg = load_cfg(args.cfg)
+    res = run_once(args.csv, cfg, debug=args.debug)
 
     if "error" in res:
         line = f"{res.get('symbol', '?')}: ERROR {res['error']}"

--- a/scripts/realtime.py
+++ b/scripts/realtime.py
@@ -1,5 +1,6 @@
 import argparse
 from csp.pipeline.realtime_v2 import run_once
+from csp.utils.io import load_cfg
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
@@ -7,5 +8,6 @@ if __name__ == "__main__":
     ap.add_argument("--cfg", default="csp/configs/strategy.yaml")
     ap.add_argument("--debug", action="store_true")
     args = ap.parse_args()
-    out = run_once(args.csv, args.cfg, debug=args.debug)
+    cfg = load_cfg(args.cfg)
+    out = run_once(args.csv, cfg, debug=args.debug)
     print(out)

--- a/scripts/realtime_multi.py
+++ b/scripts/realtime_multi.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import argparse
 import json
 from dateutil import tz
-import yaml
 
 from csp.data.fetcher import update_csv_with_latest
 from csp.pipeline.realtime_v2 import run_once
 TZ_TW = tz.gettz("Asia/Taipei")
 from csp.utils.notifier import notify
+from csp.utils.io import load_cfg
 
 
 def main():
@@ -17,7 +17,7 @@ def main():
     ap.add_argument("--debug", action="store_true")
     args = ap.parse_args()
 
-    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    cfg = load_cfg(args.cfg)
     symbols = cfg.get("symbols", [])
     csv_map = (cfg.get("io", {}) or {}).get("csv_paths", {})
     live_cfg = (cfg.get("io", {}) or {}).get("live_fetch", {}) or {}
@@ -42,7 +42,7 @@ def main():
                 stale = True
         try:
             # run_once 會自動挑選 models/<SYMBOL>/ 或全域 models/
-            res = run_once(csv_path, cfg_path=args.cfg, debug=args.debug)
+            res = run_once(csv_path, cfg, debug=args.debug)
         except Exception as e:
             res = {"symbol": sym, "side": None, "error": str(e)}
         if stale:

--- a/scripts/run_bt_v2.py
+++ b/scripts/run_bt_v2.py
@@ -2,7 +2,7 @@
 import argparse, json
 from pathlib import Path
 from csp.backtesting.backtest_v2 import run_backtest_for_symbol
-import yaml
+from csp.utils.io import load_cfg
 
 def main():
     ap = argparse.ArgumentParser()
@@ -12,7 +12,7 @@ def main():
     args = ap.parse_args()
 
     cfg_path = args.cfg
-    cfg = yaml.safe_load(Path(cfg_path).read_text(encoding="utf-8"))
+    cfg = load_cfg(cfg_path)
     symbols = cfg.get("symbols", [])
     targets = symbols if args.symbol.upper() == "ALL" else [args.symbol]
 
@@ -22,7 +22,7 @@ def main():
     for sym in targets:
         csv_path = cfg["io"]["csv_paths"][sym]
         print(f"[RUN] {sym} days={args.days} csv={csv_path}")
-        r = run_backtest_for_symbol(csv_path, cfg_path, symbol=sym)
+        r = run_backtest_for_symbol(csv_path, cfg, symbol=sym)
         results[sym] = r["metrics"]
         # 存交易明細
         (out_dir / f"{sym}_trades.csv").write_text(

--- a/scripts/train_h16.py
+++ b/scripts/train_h16.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 from csp.models.train_h16_dynamic import train
+from csp.utils.io import load_cfg
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
@@ -10,5 +11,6 @@ if __name__ == "__main__":
     args = ap.parse_args()
     if args.outdir:
         Path(args.outdir).mkdir(parents=True, exist_ok=True)
-    res = train(args.csv, args.cfg, models_dir_override=args.outdir)
+    cfg = load_cfg(args.cfg)
+    res = train(args.csv, cfg, models_dir_override=args.outdir)
     print(res)

--- a/scripts/train_multi.py
+++ b/scripts/train_multi.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 import argparse
 from pathlib import Path
-import yaml
 from csp.models.train_h16_dynamic import train
+from csp.utils.io import load_cfg
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--cfg", default="csp/configs/strategy.yaml")
     args = ap.parse_args()
 
-    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    cfg = load_cfg(args.cfg)
     csv_map = cfg["io"]["csv_paths"]
     base_models = Path(cfg["io"]["models_dir"])
 
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         out_dir = base_models / sym
         out_dir.mkdir(parents=True, exist_ok=True)
         print(f"[TRAIN] {sym} <- {csv_path}  -> {out_dir}")
-        res = train(csv_path, args.cfg, models_dir_override=str(out_dir), symbol=sym)
+        res = train(csv_path, cfg, models_dir_override=str(out_dir), symbol=sym)
         pr = res.get("positive_ratio")
         if pr is not None:
             print(f"[INFO] {sym} positive ratio={pr:.4f}")

--- a/scripts/train_multi_cls.py
+++ b/scripts/train_multi_cls.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import json
-import yaml
 import pandas as pd
 from csp.features.h16 import build_features_15m_4h
 from csp.core.feature import add_features
 from csp.data.labeling import make_labels
 from csp.models.classifier_multi import MultiThresholdClassifier
 from csp.utils.config import get_symbol_features
+from csp.utils.io import load_cfg
 
 
 def load_csv(csv_path: str, days: int | None = None) -> pd.DataFrame:
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     ap.add_argument("--days", type=int, default=None)
     args = ap.parse_args()
 
-    cfg = yaml.safe_load(open(args.cfg, "r", encoding="utf-8"))
+    cfg = load_cfg(args.cfg)
     csv_map = cfg["io"]["csv_paths"]
     model_cfg = cfg.get("model", {})
     horizons = model_cfg.get("horizons", [16])


### PR DESCRIPTION
## Summary
- add `csp.utils.io.load_cfg` to load YAML path or dict
- ensure scripts and core functions parse `cfg` to dict and assert type
- guard config helpers like `get_symbol_features`
- document `load_cfg` usage

## Testing
- `PYTHONPATH=. python scripts/train_multi.py --cfg csp/configs/strategy.yaml`
- `PYTHONPATH=. python scripts/backtest_multi.py --cfg csp/configs/strategy.yaml --days 30 --save-summary --out-dir reports --format both --fetch none`
- `PYTHONPATH=. python scripts/realtime_loop.py --cfg csp/configs/strategy.yaml --delay-sec 15` *(interrupted)*
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa152c2f04832d9f91c57b70ba9713