### PR TITLE
feat: harden realtime pipeline against missing models and stale data

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ python scripts\backtest_multi.py --cfg csp\configs\strategy.yaml --save-summary 
 - **日期區間（初始化 warmup）**：
   - 在初始化歷史（做特徵/狀態建立）時，可用 **環境變數** 限縮歷史區間，不影響之後的即時抓取。
 
+#### 故障排除
+- `NONE | score=0.00 (reason=no_models_loaded)`：找不到模型檔或檔案不完整。
+- `NONE | score=0.00 (reason=feature_nan)`：最新一根特徵含 NaN，修補失敗。
+- `NONE | score=0.00 (reason=stale_data)`：最新 K 線落後目前時間超過 15 分鐘。
+- `NONE | score=0.00 (reason=empty_or_invalid_inputs)`：匯總器收到空或全無效的輸入。
+
 **範例（warmup 僅用 8/1~8/10 的歷史）**
 ```cmd
 set START_DATE=2025-08-01

--- a/csp/strategy/aggregator.py
+++ b/csp/strategy/aggregator.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 import math, os, json
 import pandas as pd
+from dateutil import tz
 
+
+TZ_TW = tz.gettz("Asia/Taipei")
 
 def _weight(h: int) -> float:
     return math.sqrt(max(1, int(h)))
@@ -24,7 +27,7 @@ def aggregate_signal(prob_map: dict, enter_threshold: float = 0.75, method: str 
     clean = _clean_prob_map(prob_map)
     if not clean:
         return {"side":"NONE","score":0.0,"prob_up_max":0.0,"prob_down_max":1.0,
-                "chosen_h":None,"chosen_t":None,"reason":"empty_or_nan_prob_map"}
+                "chosen_h":None,"chosen_t":None,"reason":"empty_or_invalid_inputs"}
 
     if method == "majority":
         ups = sum(1 for _,p in clean.items() if p >= enter_threshold)
@@ -37,10 +40,15 @@ def aggregate_signal(prob_map: dict, enter_threshold: float = 0.75, method: str 
                 "prob_down_max":float(1.0-pu),"chosen_h":None,"chosen_t":None,
                 "reason":"majority"}
 
-    scored = [((h,t), p*_weight(h)) for (h,t), p in clean.items()]
-    if not scored:
+    scored = []
+    total_weight = 0.0
+    for (h,t), p in clean.items():
+        w = _weight(h)
+        total_weight += w
+        scored.append(((h,t), p*w))
+    if not scored or total_weight <= 0 or all((s is None or math.isnan(s[1]) or s[1]==0.0) for s in scored):
         return {"side":"NONE","score":0.0,"prob_up_max":0.0,"prob_down_max":1.0,
-                "chosen_h":None,"chosen_t":None,"reason":"scored_empty"}
+                "chosen_h":None,"chosen_t":None,"reason":"empty_or_invalid_inputs"}
     (chosen_ht, score) = max(scored, key=lambda x: x[1])
     (ch, ct) = chosen_ht
     pu = max(clean.values())
@@ -52,48 +60,66 @@ def aggregate_signal(prob_map: dict, enter_threshold: float = 0.75, method: str 
 
 
 # get_latest_signal（如已存在，請覆蓋為更嚴格版）
-def get_latest_signal(symbol: str, cfg: dict, fresh_min: float = 5.0) -> dict | None:
+def get_latest_signal(symbol: str, cfg: dict, fresh_min: float = 5.0, *, debug: bool = False) -> dict | None:
     from csp.core.feature import add_features
     try:
         from csp.models.classifier_multi import MultiThresholdClassifier
     except Exception:
-        return None
+        return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "no_models_loaded"}
 
     csv_path = cfg["io"]["csv_paths"].get(symbol)
     if not csv_path or not os.path.exists(csv_path):
-        return None
+        return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "no_data"}
 
     df = pd.read_csv(csv_path)
     if "timestamp" not in df.columns:
-        return None
+        return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "no_timestamp"}
     ts = pd.to_datetime(df["timestamp"].iloc[-1], utc=True)
-    age_min = (pd.Timestamp.utcnow() - ts).total_seconds()/60.0
-    if age_min > fresh_min:
+    now_utc = pd.Timestamp.utcnow()
+    lag_minutes = (now_utc - ts).total_seconds() / 60.0
+    print(f"[TS] {symbol} latest_kline_ts UTC={ts.isoformat()} | TW={ts.tz_convert(TZ_TW).isoformat()}")
+    print(f"[TS] {symbol} now UTC={now_utc.isoformat()} | TW={now_utc.tz_convert(TZ_TW).isoformat()} | lag_minutes={lag_minutes:.2f}")
+    if lag_minutes > 15:
+        return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "stale_data"}
+    if lag_minutes > fresh_min:
         return None
 
     dff = add_features(df.copy())
 
     model_dir = os.path.join(cfg["io"].get("models_dir","models"), symbol, "cls_multi")
+    if debug:
+        files = os.listdir(model_dir) if os.path.exists(model_dir) else []
+        print(f"[DEBUG] model_dir={model_dir} files={files} total={len(files)}")
     meta_path = os.path.join(model_dir, "meta.json")
     if not os.path.exists(meta_path):
-        return None
+        return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "no_models_loaded"}
     meta = json.load(open(meta_path, "r", encoding="utf-8"))
     feat_cols = meta.get("feature_columns") or []
     if not feat_cols:
-        return None
+        return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "no_models_loaded"}
     for c in feat_cols:
         if c not in dff.columns:
-            return None
+            return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "feature_missing"}
 
     X = dff[feat_cols].tail(1)
-    if X.isna().any().any():
-        return None
+    if X.isna().any(axis=1).iloc[0]:
+        nan_cols = X.columns[X.isna().any()].tolist()
+        if debug:
+            print(f"[WARN] feature NaN columns: {nan_cols}")
+        dff[feat_cols] = dff[feat_cols].ffill()
+        X = dff[feat_cols].tail(1)
+        if X.isna().any(axis=1).iloc[0]:
+            return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "feature_nan"}
 
     m = MultiThresholdClassifier.load(model_dir)
     prob_map = m.predict_proba(X)
     th = cfg.get("strategy",{}).get("enter_threshold",0.75)
     method = cfg.get("strategy",{}).get("aggregator_method","max_weighted")
     sig = aggregate_signal(prob_map, enter_threshold=th, method=method)
+    if not sig.get("side"):
+        sig["side"] = "NONE"
+    if sig.get("score") is None or math.isnan(sig.get("score")):
+        sig["score"] = 0.0
     sig["symbol"] = symbol
     sig["ts"] = pd.Timestamp.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     return sig

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,9 @@ cd "$APP_DIR"
 # 確保所有權
 chown -R deploy:deploy "$APP_DIR"
 
+# 清除可能殘留的日期限制環境變數
+unset START_DATE END_DATE
+
 # venv
 if [ ! -x .venv/bin/python ]; then
   python3 -m venv .venv

--- a/scripts/realtime_multi.py
+++ b/scripts/realtime_multi.py
@@ -58,16 +58,18 @@ def main():
 
         side_display = r["side"].upper() if r.get("side") else "WAIT"
         price = r.get("price")
-        pu = r.get("proba_up")
+        score = r.get("score", r.get("proba_up", 0.0))
         tp = r.get("tp")
         sl = r.get("sl")
 
         note = " [STALE DATA]" if r.get("warning") else ""
-        base = f"{sym}: {side_display} | P={price:.2f} | proba_up={pu:.3f}{note}"
-        if r.get("side"):
+        base = f"{sym}: {side_display} | P={price:.2f} | score={score:.3f}{note}"
+        if r.get("side") and r["side"] not in ("NONE", None):
             base += f" | TP={tp:.2f} | SL={sl:.2f}"
         if r.get("diag_low_var"):
             base += " [DIAG:LOW VAR]"
+        if r.get("reason"):
+            base += f" (reason={r['reason']})"
         lines.append(base)
 
     msg = "\n".join(lines)


### PR DESCRIPTION
## Summary
- add robust model loading with diagnostics and stale-data handling in realtime pipeline
- guard against NaN features and invalid aggregator inputs
- document realtime troubleshooting and clean START_DATE/END_DATE in deploy

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac16d46010832d86a08756667bdfea