### PR TITLE
Align realtime 15m bars and add systemd timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,19 @@ python scripts\backtest_multi.py --cfg csp\configs\strategy.yaml --save-summary 
 #### 故障排除
 - `NONE | score=0.00 (reason=no_models_loaded)`：找不到模型檔或檔案不完整。
 - `NONE | score=0.00 (reason=feature_nan)`：最新一根特徵含 NaN，修補失敗。
+
+### systemd 範例
+本專案提供 `systemd/trader.service` 與 `systemd/trader.timer` 兩個範例檔案。
+- `trader.service` 在啟動前會 `ExecStartPre=/bin/sleep 15`，避免過早讀取未收盤的資料，實際執行腳本 `run_realtime.sh`。
+- `trader.timer` 以 `OnCalendar=*:0/15` 每 15 分鐘觸發，並設定 `Persistent=true` 與 `AccuracySec=1s`。
+
+安裝方式：
+```bash
+sudo cp systemd/trader.service /etc/systemd/system/
+sudo cp systemd/trader.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now trader.timer
+```
 - `NONE | score=0.00 (reason=stale_data)`：最新 K 線落後目前時間超過 15 分鐘。
 - `NONE | score=0.00 (reason=empty_or_invalid_inputs)`：匯總器收到空或全無效的輸入。
 

--- a/csp/data/binance.py
+++ b/csp/data/binance.py
@@ -68,5 +68,5 @@ def merge_history_and_live(hist_df: pd.DataFrame, live_df: pd.DataFrame) -> pd.D
     if live_df is None or live_df.empty:
         return hist_df
     df = pd.concat([hist_df, live_df], ignore_index=True)
-    df = df.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)
+    df = df.drop_duplicates(subset=["timestamp"], keep="last").sort_values("timestamp").reset_index(drop=True)
     return df

--- a/deploy.sh
+++ b/deploy.sh
@@ -33,7 +33,16 @@ DAYS=360 $PY scripts/train_multi.py --cfg csp/configs/strategy.yaml
 echo "[deploy] backtest optimization (60 days)"
 $PY scripts/feature_optimize.py --cfg csp/configs/strategy.yaml --days 60
 
-# 重啟/觸發
+# 安裝 systemd service/timer
+if [ -d systemd ]; then
+  sudo cp systemd/trader.service /etc/systemd/system/trader.service
+  sudo cp systemd/trader.timer /etc/systemd/system/trader.timer
+  sudo systemctl daemon-reload
+  sudo systemctl enable trader.timer
+  sudo systemctl start trader.timer
+fi
+
+# 重啟/觸發一次性服務
 #sudo -n /usr/bin/systemctl restart trader
 sudo -n /usr/bin/systemctl start trader-once.service
 

--- a/scripts/realtime_loop.py
+++ b/scripts/realtime_loop.py
@@ -29,25 +29,13 @@ FRESH_MIN = 5.0  # 資料新鮮度門檻（分鐘）
 
 
 def process_symbol(symbol: str, cfg: dict):
-    # 1) 檢查資料新鮮度
-    csv_path = cfg["io"]["csv_paths"][symbol]
-    df = pd.read_csv(csv_path)
-    ts = pd.to_datetime(df["timestamp"].iloc[-1], utc=True)
-    age_min = (pd.Timestamp.utcnow() - ts).total_seconds() / 60.0
-    if age_min > FRESH_MIN:
-        notify_guard(
-            "data_lag",
-            {"symbol": symbol, "age_min": round(age_min, 2), "last_ts": str(ts)},
-        )
-        return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "data_lag"}
-
-    # 2) 取得最新訊號（內部會嚴格比對 meta.feature_columns 與特徵 NaN）
+    # 取得最新訊號（內部已處理資料新鮮度與缺漏補齊）
     sig = get_latest_signal(symbol, cfg, fresh_min=FRESH_MIN)
     if not sig:
         notify_guard("signal_unavailable", {"symbol": symbol})
         return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "signal_unavailable"}
 
-    # 3) 格式化得分，避免 NaN
+    # 格式化得分，避免 NaN
     score = 0.0
     s = sig.get("score")
     if s is not None and not (isinstance(s, float) and math.isnan(s)):

--- a/systemd/trader.service
+++ b/systemd/trader.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Crypto Strategy Realtime Loop
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/crypto_strategy_project
+ExecStartPre=/bin/sleep 15
+ExecStart=/opt/crypto_strategy_project/run_realtime.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/trader.timer
+++ b/systemd/trader.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run trader.service every 15 minutes
+
+[Timer]
+OnCalendar=*:0/15
+Persistent=true
+AccuracySec=1s
+Unit=trader.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- align Binance fetches to 15m closes and dedupe CSV rows by timestamp
- harden realtime signal generation with refresh retries, NaN feature guard and deterministic logs
- document and provide systemd service/timer with pre-start delay

## Testing
- `pytest`
- `python - <<'PY'
import pandas as pd
from csp.strategy.aggregator import get_latest_signal
from csp.utils.io import load_cfg
orig = pd.Timestamp.utcnow
pd.Timestamp.utcnow = staticmethod(lambda: pd.Timestamp('2025-08-14 16:47:00', tz='UTC'))
try:
    cfg = load_cfg('csp/configs/strategy.yaml')
    res = get_latest_signal('BTCUSDT', cfg, fresh_min=5.0)
    print(res)
finally:
    pd.Timestamp.utcnow = orig
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac234e38cc832d88cda1e7c866e6ba