### PR TITLE
Align Binance timestamps and guard realtime scores

### DIFF
--- a/scripts/realtime_multi.py
+++ b/scripts/realtime_multi.py
@@ -6,6 +6,7 @@ from dateutil import tz
 
 from csp.data.fetcher import update_csv_with_latest
 from csp.pipeline.realtime_v2 import run_once
+from csp.strategy.aggregator import sanitize_score
 TZ_TW = tz.gettz("Asia/Taipei")
 from csp.utils.notifier import notify
 from csp.utils.io import load_cfg
@@ -45,6 +46,7 @@ def main():
             res = run_once(csv_path, cfg, debug=args.debug)
         except Exception as e:
             res = {"symbol": sym, "side": None, "error": str(e)}
+        res["score"] = sanitize_score(res.get("score", res.get("proba_up")))
         if stale:
             res["warning"] = "STALE DATA"
         results[sym] = res
@@ -58,7 +60,7 @@ def main():
 
         side_display = r["side"].upper() if r.get("side") else "WAIT"
         price = r.get("price")
-        score = r.get("score", r.get("proba_up", 0.0))
+        score = sanitize_score(r.get("score", r.get("proba_up", 0.0)))
         tp = r.get("tp")
         sl = r.get("sl")
 


### PR DESCRIPTION
## Summary
- Align fetched kline timestamps to exact 15m close and allow endTime in fetch helpers
- Refresh CSV with range fetch on stale data and aggregate with NaN-safe logic
- Sanitize realtime scores and remove stale-data warnings in realtime scripts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad76376cac832d8564171dab3f1525