### PR TITLE
Add diagnostic logs for realtime signals

### DIFF
--- a/.github/workflows/realtime.yml
+++ b/.github/workflows/realtime.yml
@@ -1,0 +1,21 @@
+name: Realtime
+
+on:
+  workflow_dispatch:
+
+jobs:
+  realtime:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run realtime prediction with diagnostics
+        run: |
+          python scripts/predict_and_notify.py --cfg csp/configs/strategy.yaml
+        continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -302,6 +302,23 @@ m = MultiThresholdClassifier.load("models/BTCUSDT/cls_multi")
 probs = m.predict_proba(df_features.tail(1))
 ```
 
+## 🔍 CI Debugging with Diagnostic Logs
+
+To investigate why signals may show `NONE | score=nan`, the CI workflow now includes a step that runs:
+
+```bash
+python scripts/predict_and_notify.py --cfg csp/configs/strategy.yaml
+```
+
+During CI runs, you can check the GitHub Actions logs for lines starting with `[DIAG]`, which provide:
+
+- Feature NaN counts and values of the last row
+- Model type and availability of `predict_proba`
+- Probability outputs from the model
+- Detailed reason if `score=nan` (e.g., missing features)
+
+These logs are for debugging only and do not affect trading logic.
+
 
 ---
 

--- a/csp/pipeline/realtime_v2.py
+++ b/csp/pipeline/realtime_v2.py
@@ -262,7 +262,18 @@ def run_once(csv_path: str, cfg: Dict[str, Any] | str, *, debug: bool | None = N
     model = bundle["model"]
     scaler = bundle["scaler"]
     feature_cols = bundle["feature_names"]
-    X = feats[feature_cols].values
+    X = feats[feature_cols]
+    print(
+        f"[DIAG] X last row finite? {np.isfinite(X.iloc[-1].fillna(0)).all()} "
+        f"nan_count={X.iloc[-1].isna().sum()}"
+    )
+    print(f"[DIAG] X last row values={X.iloc[-1].to_dict()}")
+    print(f"[DIAG] model={type(model)}, has_proba={hasattr(model, 'predict_proba')}")
+    try:
+        _diag_proba = model.predict_proba(X.iloc[[-1]])[0]
+        print(f"[DIAG] proba={_diag_proba}")
+    except Exception as e:
+        print(f"[DIAG] predict_proba failed: {e}")
     Xs = scaler.transform(X)
 
     if bundle["model_type"] == "sklearn":
@@ -322,4 +333,5 @@ def run_once(csv_path: str, cfg: Dict[str, Any] | str, *, debug: bool | None = N
         "tp": tp,
         "sl": sl,
         "diag_low_var": diag_low_var,
+        "diag_X_last": X.iloc[-1].to_dict(),
     }

--- a/scripts/predict_and_notify.py
+++ b/scripts/predict_and_notify.py
@@ -2,20 +2,37 @@ from __future__ import annotations
 import argparse
 import json
 
+import numpy as np
+import pandas as pd
+
 from csp.pipeline.realtime_v2 import run_once
-from csp.utils.notifier import notify
+from csp.utils.notifier import notify as base_notify
 from csp.utils.io import load_cfg
+
+
+def notify(message, telegram_cfg, *, score=None, x_last=None):
+    if score is not None and np.isnan(score):
+        series = pd.Series(x_last)
+        nan_cols = series[series.isna()].index.tolist()
+        print(f"[DIAG] Signal=NONE | score=nan | reason=NAN_FEATURES | cols={nan_cols}")
+    base_notify(message, telegram_cfg)
 
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--csv", required=True, help="Path to 15m CSV (latest rows used)")
+    ap.add_argument("--csv", help="Path to 15m CSV (latest rows used)")
     ap.add_argument("--cfg", default="csp/configs/strategy.yaml")
     ap.add_argument("--debug", action="store_true")
     args = ap.parse_args()
 
     cfg = load_cfg(args.cfg)
-    res = run_once(args.csv, cfg, debug=args.debug)
+    csv_path = args.csv
+    if not csv_path:
+        csv_paths = cfg.get("io", {}).get("csv_paths", {})
+        csv_path = next(iter(csv_paths.values()), None)
+        if not csv_path:
+            raise ValueError("--csv not provided and cfg.io.csv_paths empty")
+    res = run_once(csv_path, cfg, debug=args.debug)
 
     if "error" in res:
         line = f"{res.get('symbol', '?')}: ERROR {res['error']}"
@@ -26,7 +43,12 @@ def main():
             line += f" | TP={res['tp']:.2f} | SL={res['sl']:.2f}"
         if res.get("diag_low_var"):
             line += " [DIAG:LOW VAR]"
-    notify(line, cfg.get("notify", {}).get("telegram"))
+    notify(
+        line,
+        cfg.get("notify", {}).get("telegram"),
+        score=res.get("score"),
+        x_last=res.get("diag_X_last"),
+    )
     print(json.dumps(res, ensure_ascii=False, indent=2))
 
 


### PR DESCRIPTION
## Summary
- print feature, model, and probability diagnostics during realtime inference
- log NaN feature reasons in notification wrapper
- add CI workflow step to run realtime prediction with diagnostics
- document how to use CI diagnostic logs in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b09803556c832d8e5c50f77ceec9da