### PR TITLE
Normalize timezone handling to UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ realtime:
 - 以 15 分鐘 K 線為主，欄位需含 `timestamp`（可被 `pandas.to_datetime(..., utc=True)` 解析）、`open/high/low/close/volume` 等。
 - 建議資料時間軸無重複且已排序。
 
+### Timezones
+- 整個流程（訓練 / 回測 / 即時）內部一律使用 **UTC**。
+- 讀取 CSV 時會以 `utc=True` 解析時間戳並透過 `ensure_utc_index` 設成 UTC index。
+- bar 對齊與 `now` 取得皆以 UTC 計算；如需顯示本地時間僅在最後轉換（例如 `Asia/Taipei`）。
+
 ---
 
 ## 快速開始

--- a/csp/utils/tz.py
+++ b/csp/utils/tz.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import numpy as np
+
+UTC = "UTC"
+
+def ensure_utc_index(df, ts_col="timestamp"):
+    """
+    Ensure df.index is UTC tz-aware, using ts_col if provided.
+    - If ts_col exists, parse with utc=True then set_index(ts_col).
+    - If index is datetime-like and tz-naive, tz_localize('UTC').
+    - If index is tz-aware, convert to UTC.
+    """
+    if ts_col in df.columns:
+        df[ts_col] = pd.to_datetime(df[ts_col], utc=True)
+        df = df.set_index(ts_col, drop=True)
+    if getattr(df.index, "tz", None) is None:
+        df.index = df.index.tz_localize(UTC)
+    else:
+        df.index = df.index.tz_convert(UTC)
+    return df.sort_index()
+
+def ensure_utc_ts(ts):
+    """Return a UTC-aware pandas Timestamp."""
+    ts = pd.Timestamp(ts)
+    if ts.tzinfo is None:
+        return ts.tz_localize(UTC)
+    return ts.tz_convert(UTC)
+
+def now_utc():
+    return pd.Timestamp.now(tz=UTC)
+
+def floor_to(ts, freq="15min"):
+    ts = ensure_utc_ts(ts)
+    return ts.floor(freq)
+
+def ceil_to(ts, freq="15min"):
+    ts = ensure_utc_ts(ts)
+    return ts.ceil(freq)

--- a/scripts/backtest_multi.py
+++ b/scripts/backtest_multi.py
@@ -15,6 +15,7 @@ import requests
 from csp.backtesting.backtest_v2 import run_backtest_for_symbol
 from csp.metrics.report import summarize
 from csp.utils.io import load_cfg
+from csp.utils.tz import ensure_utc_ts
 
 BINANCE_BASE = "https://api.binance.com"
 
@@ -107,8 +108,7 @@ def append_missing_15m(csv_path: str, symbol: str, end_utc: datetime) -> None:
 def slice_by_days(csv_path: str, days: int, end_utc: datetime) -> Tuple[pd.Timestamp, pd.Timestamp]:
     end_ts = pd.Timestamp(end_utc)
     start_ts = end_ts - pd.Timedelta(days=days)
-    return (start_ts.tz_convert("UTC") if start_ts.tz is not None else start_ts.tz_localize("UTC"),
-            end_ts.tz_convert("UTC") if end_ts.tz is not None else end_ts.tz_localize("UTC"))
+    return (ensure_utc_ts(start_ts), ensure_utc_ts(end_ts))
 
 def main():
     ap = argparse.ArgumentParser()

--- a/scripts/diag_signal.py
+++ b/scripts/diag_signal.py
@@ -1,17 +1,15 @@
 import os, json, math, argparse
 import pandas as pd
-from datetime import datetime, timezone
+from datetime import datetime
 import pytz
+
+from csp.utils.tz import ensure_utc_ts
 
 
 def _fmt_ts(ts_utc):
     tz = pytz.timezone("Asia/Taipei")
-    ts = pd.Timestamp(ts_utc)
-    if ts.tzinfo is None:
-        ts = ts.tz_localize(timezone.utc)
-    else:
-        ts = ts.tz_convert(timezone.utc)
-    return ts.astimezone(tz).strftime("%Y-%m-%d %H:%M:%S")
+    ts = ensure_utc_ts(ts_utc)
+    return ts.tz_convert(tz).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def main():

--- a/scripts/train_multi_cls.py
+++ b/scripts/train_multi_cls.py
@@ -9,12 +9,14 @@ from csp.data.labeling import make_labels
 from csp.models.classifier_multi import MultiThresholdClassifier
 from csp.utils.config import get_symbol_features
 from csp.utils.io import load_cfg
+from csp.utils.tz import ensure_utc_index
 
 
 def load_csv(csv_path: str, days: int | None = None) -> pd.DataFrame:
     df = pd.read_csv(csv_path)
-    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
-    df = df.set_index("timestamp").sort_index()
+    df = ensure_utc_index(df, ts_col="timestamp")
+    print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
+    assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
     if days is not None:
         limit = days * 24 * 60 // 15
         df = df.iloc[-limit:]

--- a/tests/test_tz_utils.py
+++ b/tests/test_tz_utils.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from csp.utils.tz import ensure_utc_index, UTC
+
+
+def test_ensure_utc_index_naive_and_tw():
+    df_naive = pd.DataFrame({
+        "timestamp": ["2024-01-01 00:00:00", "2024-01-01 00:15:00"],
+        "open": [1, 2],
+        "high": [1, 2],
+        "low": [1, 2],
+        "close": [1, 2],
+    })
+    out1 = ensure_utc_index(df_naive, ts_col="timestamp")
+    assert str(out1.index.tz) == UTC
+
+    df_tw = pd.DataFrame({
+        "timestamp": pd.to_datetime(["2024-01-01 08:00:00", "2024-01-01 08:15:00"]).tz_localize("Asia/Taipei"),
+        "open": [1, 2],
+        "high": [1, 2],
+        "low": [1, 2],
+        "close": [1, 2],
+    })
+    out2 = ensure_utc_index(df_tw, ts_col="timestamp")
+    assert str(out2.index.tz) == UTC


### PR DESCRIPTION
## Summary
- add timezone utility helpers for consistent UTC handling
- normalize CSV loaders and realtime scripts to `ensure_utc_index` with diagnostics
- replace unsafe `tz_localize` calls with `ensure_utc_ts`

## Testing
- `pytest -q`
- `PYTHONPATH=. python scripts/predict_and_notify.py --cfg csp/configs/strategy.yaml --csv resources/btc_15m.csv` *(fails: KeyError: 'tp')*

------
https://chatgpt.com/codex/tasks/task_e_68b0f3c0f95c832d943dd796bc422400