### PR TITLE
Fix timestamp index handling in feature optimizer

### DIFF
--- a/scripts/feature_optimize.py
+++ b/scripts/feature_optimize.py
@@ -53,7 +53,33 @@ def main() -> None:
     for sym in symbols:
         csv_path = cfg["io"]["csv_paths"][sym]
         df = load_15m_csv(csv_path)
-        idx = pd.DatetimeIndex(df["timestamp"])
+        # Ensure a timestamp column exists for legacy paths
+        if "timestamp" not in df.columns:
+            df["timestamp"] = df.index
+
+        # Robust timestamp extraction: column or index
+
+        def _get_utc_index(df):
+            # Case A: explicit 'timestamp' column exists
+            if "timestamp" in df.columns:
+                ts = pd.to_datetime(df["timestamp"], utc=True)
+                return pd.DatetimeIndex(ts, tz="UTC")
+            # Case B: already on DatetimeIndex
+            if isinstance(df.index, pd.DatetimeIndex):
+                if df.index.tz is None:
+                    return df.index.tz_localize("UTC")
+                return df.index.tz_convert("UTC")
+            # Case C: fallback - try to coerce an index to datetime
+            idx = pd.to_datetime(df.index, utc=True, errors="raise")
+            return pd.DatetimeIndex(idx, tz="UTC")
+
+        idx = _get_utc_index(df)
+        # DIAG
+        print(f"[DIAG] feature_optimize: idx.tz={getattr(idx, 'tz', None)}, has_col={'timestamp' in df.columns}, columns={list(df.columns)[:8]}...")
+
+        df = df.set_index(idx)
+        assert str(df.index.tz) == "UTC", "[DIAG] feature_optimize: index must be UTC"
+
         start_ts, end_ts = resolve_time_range_like(env_args, idx)
         print(f"[OPT] {sym} {start_ts}~{end_ts} trials={args.trials}")
         study = optimize_symbol(args.cfg, sym, start_ts, end_ts, args.trials, base_out)


### PR DESCRIPTION
## Summary
- handle timestamp from either index or column when optimizing features
- ensure legacy timestamp column exists and enforce UTC index
- add diagnostics for timestamp extraction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0fca17bc4832d9d1d6b952887c200