### PR TITLE
refactor: add safe timezone helpers and normalize UTC usage

### DIFF
--- a/csp/backtesting/backtest_v2.py
+++ b/csp/backtesting/backtest_v2.py
@@ -8,8 +8,12 @@ import pandas as pd
 import xgboost as xgb
 import joblib
 from csp.utils.io import load_cfg
-from csp.utils.tz import ensure_utc_ts
-from csp.utils.timeframe import normalize_df_ts
+from csp.utils.tz_safe import (
+    normalize_df_to_utc_index,
+    safe_ts_to_utc,
+    now_utc,
+    floor_utc,
+)
 
 from csp.data.loader import load_15m_csv
 from csp.features.h16 import build_features_15m_4h
@@ -160,11 +164,13 @@ def run_backtest_for_symbol(csv_path: str, cfg: Dict[str, Any] | str, symbol: Op
         pass
     df15 = load_15m_csv(csv_path)
     # Normalize df15 to UTC DatetimeIndex (works whether there's a 'timestamp' column or not)
-    df15 = normalize_df_ts(df15, ts_col="timestamp" if "timestamp" in df15.columns else None)
+    df15 = normalize_df_to_utc_index(
+        df15, ts_col="timestamp" if "timestamp" in df15.columns else None
+    )
     # Ensure start_ts (and end_ts if exists) are UTC-aware
-    start_ts = ensure_utc_ts(start_ts)
+    start_ts = safe_ts_to_utc(start_ts)
     if 'end_ts' in locals():
-        end_ts = ensure_utc_ts(end_ts)
+        end_ts = safe_ts_to_utc(end_ts)
 
     # DIAG
     print(f"[DIAG][backtest] df15.index.tz={df15.index.tz}, head_ts={df15.index[:3].tolist()}")

--- a/csp/data/binance.py
+++ b/csp/data/binance.py
@@ -4,7 +4,12 @@ from typing import List
 import pandas as pd
 import requests
 
-from csp.utils.tz import ensure_utc_index
+from csp.utils.tz_safe import (
+    normalize_df_to_utc_index,
+    safe_ts_to_utc,
+    now_utc,
+    floor_utc,
+)
 
 
 INTERVAL_MIN = 15
@@ -35,7 +40,7 @@ def _klines_to_df(data: list, interval: str = "15m") -> pd.DataFrame:
     for c in ["open", "high", "low", "close", "volume"]:
         df[c] = df[c].astype(float)
     df = df[["timestamp", "open", "high", "low", "close", "volume"]]
-    df = ensure_utc_index(df, ts_col="timestamp")
+    df = normalize_df_to_utc_index(df, ts_col="timestamp")
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
     return df

--- a/csp/data/loader.py
+++ b/csp/data/loader.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import pandas as pd
 from pathlib import Path
 
-from csp.utils.tz import ensure_utc_index
+from csp.utils.tz_safe import (
+    normalize_df_to_utc_index,
+    safe_ts_to_utc,
+    now_utc,
+    floor_utc,
+)
 
 def _pick_timestamp_col(df: pd.DataFrame) -> str:
     # 常見欄位別名
@@ -61,7 +66,7 @@ def load_15m_csv(path: str | Path) -> pd.DataFrame:
     if "volume" in df.columns:
         cols.append("volume")
     df = df[cols]
-    df = ensure_utc_index(df, ts_col="timestamp")
+    df = normalize_df_to_utc_index(df, ts_col="timestamp")
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
     return df

--- a/csp/utils/timeframe.py
+++ b/csp/utils/timeframe.py
@@ -1,14 +1,5 @@
-import pandas as pd
+from .tz_safe import normalize_df_to_utc_index
 
-UTC = "UTC"
 
 def normalize_df_ts(df, ts_col="timestamp"):
-    if ts_col in df.columns:
-        df[ts_col] = pd.to_datetime(df[ts_col], utc=True)
-        df = df.set_index(ts_col, drop=True)
-    elif not isinstance(df.index, pd.DatetimeIndex):
-        df.index = pd.to_datetime(df.index, utc=True, errors="raise")
-    df.index = df.index.tz_localize(UTC) if df.index.tz is None else df.index.tz_convert(UTC)
-    if "timestamp" not in df.columns:
-        df["timestamp"] = df.index
-    return df.sort_index()
+    return normalize_df_to_utc_index(df, ts_col=ts_col)

--- a/csp/utils/tz.py
+++ b/csp/utils/tz.py
@@ -1,38 +1,24 @@
-import pandas as pd
-import numpy as np
+from .tz_safe import (
+    UTC,
+    safe_ts_to_utc,
+    safe_index_to_utc,
+    safe_series_to_utc,
+    normalize_df_to_utc_index,
+    now_utc,
+    floor_utc,
+    ceil_utc,
+)
 
-UTC = "UTC"
-
-def ensure_utc_index(df, ts_col="timestamp"):
-    """
-    Ensure df.index is UTC tz-aware, using ts_col if provided.
-    - If ts_col exists, parse with utc=True then set_index(ts_col).
-    - If index is datetime-like and tz-naive, tz_localize('UTC').
-    - If index is tz-aware, convert to UTC.
-    """
-    if ts_col in df.columns:
-        df[ts_col] = pd.to_datetime(df[ts_col], utc=True)
-        df = df.set_index(ts_col, drop=True)
-    if getattr(df.index, "tz", None) is None:
-        df.index = df.index.tz_localize(UTC)
-    else:
-        df.index = df.index.tz_convert(UTC)
-    return df.sort_index()
+# Backward-compatible wrappers
 
 def ensure_utc_ts(ts):
-    """Return a UTC-aware pandas Timestamp."""
-    ts = pd.Timestamp(ts)
-    if ts.tzinfo is None:
-        return ts.tz_localize(UTC)
-    return ts.tz_convert(UTC)
+    return safe_ts_to_utc(ts)
 
-def now_utc():
-    return pd.Timestamp.now(tz=UTC)
+def ensure_utc_index(df, ts_col="timestamp"):
+    return normalize_df_to_utc_index(df, ts_col=ts_col)
 
 def floor_to(ts, freq="15min"):
-    ts = ensure_utc_ts(ts)
-    return ts.floor(freq)
+    return floor_utc(ts, freq)
 
 def ceil_to(ts, freq="15min"):
-    ts = ensure_utc_ts(ts)
-    return ts.ceil(freq)
+    return ceil_utc(ts, freq)

--- a/csp/utils/tz_safe.py
+++ b/csp/utils/tz_safe.py
@@ -1,0 +1,53 @@
+import pandas as pd
+
+UTC = "UTC"
+
+def safe_ts_to_utc(ts):
+    """Return a UTC-aware pandas.Timestamp from ts (scalar)."""
+    ts = pd.Timestamp(ts)
+    if ts.tzinfo is None:
+        return ts.tz_localize(UTC)
+    return ts.tz_convert(UTC)
+
+def safe_index_to_utc(idx):
+    """Return a UTC-aware DatetimeIndex from idx."""
+    if isinstance(idx, pd.DatetimeIndex):
+        if idx.tz is None:
+            return idx.tz_localize(UTC)
+        return idx.tz_convert(UTC)
+    idx = pd.to_datetime(idx, utc=True, errors="raise")
+    return pd.DatetimeIndex(idx, tz=UTC)
+
+def safe_series_to_utc(s):
+    """Return a UTC-aware Series of datetimes."""
+    # s may be datetime64[ns], object, etc.
+    s = pd.to_datetime(s, utc=True, errors="raise")
+    return s.dt.tz_convert(UTC)
+
+def normalize_df_to_utc_index(df, ts_col="timestamp"):
+    """
+    Ensure df has a UTC DatetimeIndex using ts_col if present.
+    Also mirror a 'timestamp' column for legacy code.
+    """
+    if ts_col and ts_col in df.columns:
+        df[ts_col] = pd.to_datetime(df[ts_col], utc=True, errors="raise")
+        df = df.set_index(ts_col, drop=True)
+    elif not isinstance(df.index, pd.DatetimeIndex):
+        df.index = pd.to_datetime(df.index, utc=True, errors="raise")
+    # Make index UTC
+    if df.index.tz is None:
+        df.index = df.index.tz_localize(UTC)
+    else:
+        df.index = df.index.tz_convert(UTC)
+    if "timestamp" not in df.columns:
+        df["timestamp"] = df.index
+    return df.sort_index()
+
+def now_utc():
+    return pd.Timestamp.now(tz=UTC)
+
+def floor_utc(ts, freq="15min"):
+    return safe_ts_to_utc(ts).floor(freq)
+
+def ceil_utc(ts, freq="15min"):
+    return safe_ts_to_utc(ts).ceil(freq)

--- a/scripts/feature_optimize.py
+++ b/scripts/feature_optimize.py
@@ -10,7 +10,12 @@ from csp.data.loader import load_15m_csv
 from csp.utils.dates import resolve_time_range_like
 from csp.optimize.feature_opt import optimize_symbol, apply_best_params_to_cfg
 from csp.utils.io import load_cfg
-from csp.utils.timeframe import normalize_df_ts
+from csp.utils.tz_safe import (
+    normalize_df_to_utc_index,
+    safe_ts_to_utc,
+    now_utc,
+    floor_utc,
+)
 
 
 def _read_date_args_from_env() -> dict:
@@ -54,7 +59,9 @@ def main() -> None:
     for sym in symbols:
         csv_path = cfg["io"]["csv_paths"][sym]
         df = load_15m_csv(csv_path)
-        df = normalize_df_ts(df, ts_col="timestamp" if "timestamp" in df.columns else None)
+        df = normalize_df_to_utc_index(
+            df, ts_col="timestamp" if "timestamp" in df.columns else None
+        )
         # DIAG
         print(f"[DIAG] feature_optimize: index.tz={df.index.tz}, columns={list(df.columns)[:8]}...")
         assert str(df.index.tz) == "UTC", "[DIAG] feature_optimize: index must be UTC"

--- a/scripts/predict_and_notify.py
+++ b/scripts/predict_and_notify.py
@@ -8,7 +8,12 @@ import pandas as pd
 from csp.pipeline.realtime_v2 import run_once
 from csp.utils.notifier import notify as base_notify
 from csp.utils.io import load_cfg
-from csp.utils.timeframe import normalize_df_ts
+from csp.utils.tz_safe import (
+    normalize_df_to_utc_index,
+    safe_ts_to_utc,
+    now_utc,
+    floor_utc,
+)
 
 
 def notify(message, telegram_cfg, *, score=None, x_last=None):
@@ -35,7 +40,9 @@ def main():
             raise ValueError("--csv not provided and cfg.io.csv_paths empty")
 
     df = pd.read_csv(csv_path)
-    df = normalize_df_ts(df, ts_col="timestamp" if "timestamp" in df.columns else None)
+    df = normalize_df_to_utc_index(
+        df, ts_col="timestamp" if "timestamp" in df.columns else None
+    )
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
 

--- a/scripts/realtime_loop.py
+++ b/scripts/realtime_loop.py
@@ -19,7 +19,12 @@ from csp.utils.notifier import (
 )
 from csp.runtime.exit_watchdog import check_exit_once
 from csp.utils.io import load_cfg
-from csp.utils.tz import ensure_utc_index, ensure_utc_ts, now_utc as _now_utc, floor_to
+from csp.utils.tz_safe import (
+    normalize_df_to_utc_index,
+    safe_ts_to_utc,
+    now_utc,
+    floor_utc,
+)
 
 TW = tz.gettz("Asia/Taipei")
 
@@ -52,12 +57,12 @@ def ensure_latest_csv(symbol: str, csv_path: str, fresh_min: float = 5.0):
         df_old = pd.read_csv(csv_path)
     except FileNotFoundError:
         df_old = pd.DataFrame(columns=["timestamp","open","high","low","close","volume"])
-    df_old = ensure_utc_index(df_old, ts_col="timestamp")
+    df_old = normalize_df_to_utc_index(df_old, ts_col="timestamp")
     print(f"[DIAG] df.index.tz={df_old.index.tz}, head_ts={df_old.index[:3].tolist()}")
     assert str(df_old.index.tz) == "UTC", "[DIAG] index not UTC"
 
-    now_ts = _now_utc()
-    floor_now = floor_to(now_ts, "15min")
+    now_ts = now_utc()
+    floor_now = floor_utc(now_ts, "15min")
 
     last_ts = df_old.index.max() if len(df_old) else pd.NaT
 
@@ -85,7 +90,7 @@ def ensure_latest_csv(symbol: str, csv_path: str, fresh_min: float = 5.0):
         tmp[col] = tmp[col].astype(float)
 
     tmp = tmp[["timestamp","open","high","low","close","volume"]]
-    tmp = ensure_utc_index(tmp, ts_col="timestamp")
+    tmp = normalize_df_to_utc_index(tmp, ts_col="timestamp")
 
     merged = pd.concat([df_old, tmp])
     merged = merged[~merged.index.duplicated(keep="last")].sort_index()

--- a/scripts/train_multi_cls.py
+++ b/scripts/train_multi_cls.py
@@ -9,12 +9,19 @@ from csp.data.labeling import make_labels
 from csp.models.classifier_multi import MultiThresholdClassifier
 from csp.utils.config import get_symbol_features
 from csp.utils.io import load_cfg
-from csp.utils.timeframe import normalize_df_ts
+from csp.utils.tz_safe import (
+    normalize_df_to_utc_index,
+    safe_ts_to_utc,
+    now_utc,
+    floor_utc,
+)
 
 
 def load_csv(csv_path: str, days: int | None = None) -> pd.DataFrame:
     df = pd.read_csv(csv_path)
-    df = normalize_df_ts(df, ts_col="timestamp" if "timestamp" in df.columns else None)
+    df = normalize_df_to_utc_index(
+        df, ts_col="timestamp" if "timestamp" in df.columns else None
+    )
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
     if days is not None:

--- a/tests/test_tz_utils.py
+++ b/tests/test_tz_utils.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from csp.utils.tz import ensure_utc_index, UTC
+from csp.utils.tz_safe import normalize_df_to_utc_index, UTC
 
 
 def test_ensure_utc_index_naive_and_tw():
@@ -10,7 +10,7 @@ def test_ensure_utc_index_naive_and_tw():
         "low": [1, 2],
         "close": [1, 2],
     })
-    out1 = ensure_utc_index(df_naive, ts_col="timestamp")
+    out1 = normalize_df_to_utc_index(df_naive, ts_col="timestamp")
     assert str(out1.index.tz) == UTC
 
     df_tw = pd.DataFrame({
@@ -20,5 +20,5 @@ def test_ensure_utc_index_naive_and_tw():
         "low": [1, 2],
         "close": [1, 2],
     })
-    out2 = ensure_utc_index(df_tw, ts_col="timestamp")
+    out2 = normalize_df_to_utc_index(df_tw, ts_col="timestamp")
     assert str(out2.index.tz) == UTC


### PR DESCRIPTION
## Summary
- add `tz_safe` helper module for robust UTC-aware timestamps and indices
- replace direct `tz_localize('UTC')` calls with safe helpers across scripts, data loaders, and backtesting
- ensure all loaded DataFrames normalize to UTC and assert index timezone

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b16667ea24832d810a2cc8b674f56d