### PR TITLE
Add traceback logging for realtime per-symbol errors

### DIFF
--- a/scripts/predict_and_notify.py
+++ b/scripts/predict_and_notify.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import argparse
 import json
+import traceback
 
 import numpy as np
 import pandas as pd
@@ -46,7 +47,14 @@ def main():
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
 
-    res = run_once(csv_path, cfg, df=df, debug=args.debug)
+    symbol = (cfg.get("symbols") or ["?"])[0]
+    try:
+        res = run_once(csv_path, cfg, df=df, debug=args.debug)
+    except Exception as e:
+        tb = traceback.format_exc()
+        print(f"[ERR][{symbol}] {repr(e)}")
+        print(f"[ERR][{symbol}] traceback:\n{tb}")
+        res = {"symbol": symbol, "error": str(e)}
 
     if "error" in res:
         line = f"{res.get('symbol', '?')}: ERROR {res['error']}"

--- a/scripts/realtime_loop.py
+++ b/scripts/realtime_loop.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import time
+import traceback
 from datetime import datetime, timedelta, timezone
 
 from dateutil import tz
@@ -140,6 +141,9 @@ def run_once(cfg: dict | str, delay_sec: int | None = None) -> dict:
         try:
             res = process_symbol(sym, cfg)
         except Exception as e:
+            tb = traceback.format_exc()
+            print(f"[ERR][{sym}] {repr(e)}")
+            print(f"[ERR][{sym}] traceback:\n{tb}")
             res = {"symbol": sym, "side": "NONE", "error": str(e)}
         sig = res if res.get("side") in ("LONG", "SHORT") else None
         if res.get("price") is not None and sig:

--- a/scripts/realtime_multi.py
+++ b/scripts/realtime_multi.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import traceback
 from dateutil import tz
 
 from csp.data.fetcher import update_csv_with_latest
@@ -45,6 +46,9 @@ def main():
             # run_once 會自動挑選 models/<SYMBOL>/ 或全域 models/
             res = run_once(csv_path, cfg, debug=args.debug)
         except Exception as e:
+            tb = traceback.format_exc()
+            print(f"[ERR][{sym}] {repr(e)}")
+            print(f"[ERR][{sym}] traceback:\n{tb}")
             res = {"symbol": sym, "side": None, "error": str(e)}
         res["score"] = sanitize_score(res.get("score", res.get("proba_up")))
         if stale:


### PR DESCRIPTION
## Summary
- log full traceback if per-symbol run fails in predict_and_notify
- print stack traces for realtime_multi and realtime_loop per-symbol exceptions
- confirm realtime workflow pipes stdout/stderr to logs for CI diagnostics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b16902d388832d89d2bddc7e87e4b0