### PR TITLE
feat: add timezone-safe helpers

### DIFF
--- a/csp/backtesting/backtest_v2.py
+++ b/csp/backtesting/backtest_v2.py
@@ -9,7 +9,7 @@ import xgboost as xgb
 import joblib
 from csp.utils.io import load_cfg
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -163,10 +163,8 @@ def run_backtest_for_symbol(csv_path: str, cfg: Dict[str, Any] | str, symbol: Op
     except Exception:
         pass
     df15 = load_15m_csv(csv_path)
-    # Normalize df15 to UTC DatetimeIndex (works whether there's a 'timestamp' column or not)
-    df15 = normalize_df_to_utc_index(
-        df15, ts_col="timestamp" if "timestamp" in df15.columns else None
-    )
+    # Normalize df15 to UTC DatetimeIndex
+    df15 = normalize_df_to_utc(df15)
     # Ensure start_ts (and end_ts if exists) are UTC-aware
     start_ts = safe_ts_to_utc(start_ts)
     if 'end_ts' in locals():

--- a/csp/data/binance.py
+++ b/csp/data/binance.py
@@ -5,7 +5,7 @@ import pandas as pd
 import requests
 
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -40,7 +40,7 @@ def _klines_to_df(data: list, interval: str = "15m") -> pd.DataFrame:
     for c in ["open", "high", "low", "close", "volume"]:
         df[c] = df[c].astype(float)
     df = df[["timestamp", "open", "high", "low", "close", "volume"]]
-    df = normalize_df_to_utc_index(df, ts_col="timestamp")
+    df = normalize_df_to_utc(df)
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
     return df

--- a/csp/data/fetcher.py
+++ b/csp/data/fetcher.py
@@ -9,7 +9,7 @@ import pandas as pd
 import requests
 
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -89,7 +89,7 @@ def fetch_klines(
         df[c] = df[c].astype(float)
     df = df[["timestamp", "open", "high", "low", "close", "volume"]]
 
-    df = normalize_df_to_utc_index(df, ts_col="timestamp")
+    df = normalize_df_to_utc(df)
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
 
@@ -117,7 +117,7 @@ def update_csv_with_latest(
         df = pd.read_csv(path)
     else:
         df = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
-    df = normalize_df_to_utc_index(df, ts_col="timestamp")
+    df = normalize_df_to_utc(df)
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
 

--- a/csp/data/loader.py
+++ b/csp/data/loader.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pathlib import Path
 
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -29,6 +29,7 @@ def load_15m_csv(path: str | Path) -> pd.DataFrame:
         raise FileNotFoundError(f"CSV not found: {p}")
 
     df = pd.read_csv(p)
+    df = normalize_df_to_utc(df)
     # 欄位名稱轉小寫（保留原始名稱用於對應）
     orig_cols = df.columns.tolist()
     lower_map = {c: c.lower() for c in orig_cols}
@@ -66,7 +67,7 @@ def load_15m_csv(path: str | Path) -> pd.DataFrame:
     if "volume" in df.columns:
         cols.append("volume")
     df = df[cols]
-    df = normalize_df_to_utc_index(df, ts_col="timestamp")
+    df = normalize_df_to_utc(df)
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
     return df

--- a/csp/pipeline/realtime_v2.py
+++ b/csp/pipeline/realtime_v2.py
@@ -20,7 +20,7 @@ import numpy as np
 from dateutil import tz
 
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -194,7 +194,7 @@ def run_once(csv_path: str, cfg: Dict[str, Any] | str, *, df: pd.DataFrame | Non
     if df is None:
         df15 = load_15m_csv(csv_path)
     else:
-        df15 = normalize_df_to_utc_index(df)
+        df15 = normalize_df_to_utc(df)
         print(f"[DIAG] df.index.tz={df15.index.tz}, head_ts={df15.index[:3].tolist()}")
     assert str(df15.index.tz) == "UTC", "[DIAG] index not UTC"
     df15 = initialize_history(df15)

--- a/csp/strategy/aggregator.py
+++ b/csp/strategy/aggregator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 from csp.data.binance import fetch_klines_range
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -114,7 +114,7 @@ def read_or_fetch_latest(
         df = pd.read_csv(path)
     else:
         df = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
-    df = normalize_df_to_utc_index(df, ts_col="timestamp")
+    df = normalize_df_to_utc(df)
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
 

--- a/csp/utils/timeframe.py
+++ b/csp/utils/timeframe.py
@@ -1,5 +1,7 @@
-from .tz_safe import normalize_df_to_utc_index
+from .tz_safe import normalize_df_to_utc
 
 
 def normalize_df_ts(df, ts_col="timestamp"):
-    return normalize_df_to_utc_index(df, ts_col=ts_col)
+    if ts_col != "timestamp" and ts_col in df.columns:
+        df = df.rename(columns={ts_col: "timestamp"})
+    return normalize_df_to_utc(df)

--- a/csp/utils/tz.py
+++ b/csp/utils/tz.py
@@ -3,7 +3,7 @@ from .tz_safe import (
     safe_ts_to_utc,
     safe_index_to_utc,
     safe_series_to_utc,
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     now_utc,
     floor_utc,
     ceil_utc,
@@ -15,7 +15,9 @@ def ensure_utc_ts(ts):
     return safe_ts_to_utc(ts)
 
 def ensure_utc_index(df, ts_col="timestamp"):
-    return normalize_df_to_utc_index(df, ts_col=ts_col)
+    if ts_col != "timestamp" and ts_col in df.columns:
+        df = df.rename(columns={ts_col: "timestamp"})
+    return normalize_df_to_utc(df)
 
 def floor_to(ts, freq="15min"):
     return floor_utc(ts, freq)

--- a/scripts/backtest_multi.py
+++ b/scripts/backtest_multi.py
@@ -16,7 +16,7 @@ from csp.backtesting.backtest_v2 import run_backtest_for_symbol
 from csp.metrics.report import summarize
 from csp.utils.io import load_cfg
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -36,14 +36,13 @@ def read_local_csv(csv_path: str) -> pd.DataFrame:
             columns=["timestamp", "open", "high", "low", "close", "volume"]
         )
     df = pd.read_csv(p)
-    if "timestamp" in df.columns:
-        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
-    else:
+    df = normalize_df_to_utc(df)
+    if "timestamp" not in df.columns:
         raise ValueError(f"{csv_path} 缺少 timestamp 欄位")
     for c in ["open", "high", "low", "close"]:
         if c not in df.columns:
             raise ValueError(f"{csv_path} 缺少必要欄位：{c}")
-    df = normalize_df_to_utc_index(df, ts_col="timestamp")
+    df = normalize_df_to_utc(df)
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
     return df

--- a/scripts/diag_signal.py
+++ b/scripts/diag_signal.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytz
 
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -49,9 +49,7 @@ def main():
             continue
 
         df = pd.read_csv(csv_path)
-        df = normalize_df_to_utc_index(
-            df, ts_col="timestamp" if "timestamp" in df.columns else None
-        )
+        df = normalize_df_to_utc(df)
         print(
             f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}"
         )

--- a/scripts/feature_optimize.py
+++ b/scripts/feature_optimize.py
@@ -11,7 +11,7 @@ from csp.utils.dates import resolve_time_range_like
 from csp.optimize.feature_opt import optimize_symbol, apply_best_params_to_cfg
 from csp.utils.io import load_cfg
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -59,9 +59,7 @@ def main() -> None:
     for sym in symbols:
         csv_path = cfg["io"]["csv_paths"][sym]
         df = load_15m_csv(csv_path)
-        df = normalize_df_to_utc_index(
-            df, ts_col="timestamp" if "timestamp" in df.columns else None
-        )
+        df = normalize_df_to_utc(df)
         # DIAG
         print(f"[DIAG] feature_optimize: index.tz={df.index.tz}, columns={list(df.columns)[:8]}...")
         assert str(df.index.tz) == "UTC", "[DIAG] feature_optimize: index must be UTC"

--- a/scripts/predict_and_notify.py
+++ b/scripts/predict_and_notify.py
@@ -10,7 +10,7 @@ from csp.pipeline.realtime_v2 import run_once
 from csp.utils.notifier import notify as base_notify
 from csp.utils.io import load_cfg
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -41,9 +41,7 @@ def main():
             raise ValueError("--csv not provided and cfg.io.csv_paths empty")
 
     df = pd.read_csv(csv_path)
-    df = normalize_df_to_utc_index(
-        df, ts_col="timestamp" if "timestamp" in df.columns else None
-    )
+    df = normalize_df_to_utc(df)
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
 

--- a/scripts/realtime_loop.py
+++ b/scripts/realtime_loop.py
@@ -21,7 +21,7 @@ from csp.utils.notifier import (
 from csp.runtime.exit_watchdog import check_exit_once
 from csp.utils.io import load_cfg
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -58,7 +58,7 @@ def ensure_latest_csv(symbol: str, csv_path: str, fresh_min: float = 5.0):
         df_old = pd.read_csv(csv_path)
     except FileNotFoundError:
         df_old = pd.DataFrame(columns=["timestamp","open","high","low","close","volume"])
-    df_old = normalize_df_to_utc_index(df_old, ts_col="timestamp")
+    df_old = normalize_df_to_utc(df_old)
     print(f"[DIAG] df.index.tz={df_old.index.tz}, head_ts={df_old.index[:3].tolist()}")
     assert str(df_old.index.tz) == "UTC", "[DIAG] index not UTC"
 
@@ -91,7 +91,7 @@ def ensure_latest_csv(symbol: str, csv_path: str, fresh_min: float = 5.0):
         tmp[col] = tmp[col].astype(float)
 
     tmp = tmp[["timestamp","open","high","low","close","volume"]]
-    tmp = normalize_df_to_utc_index(tmp, ts_col="timestamp")
+    tmp = normalize_df_to_utc(tmp)
 
     merged = pd.concat([df_old, tmp])
     merged = merged[~merged.index.duplicated(keep="last")].sort_index()

--- a/scripts/train_multi_cls.py
+++ b/scripts/train_multi_cls.py
@@ -10,7 +10,7 @@ from csp.models.classifier_multi import MultiThresholdClassifier
 from csp.utils.config import get_symbol_features
 from csp.utils.io import load_cfg
 from csp.utils.tz_safe import (
-    normalize_df_to_utc_index,
+    normalize_df_to_utc,
     safe_ts_to_utc,
     now_utc,
     floor_utc,
@@ -19,9 +19,7 @@ from csp.utils.tz_safe import (
 
 def load_csv(csv_path: str, days: int | None = None) -> pd.DataFrame:
     df = pd.read_csv(csv_path)
-    df = normalize_df_to_utc_index(
-        df, ts_col="timestamp" if "timestamp" in df.columns else None
-    )
+    df = normalize_df_to_utc(df)
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
     if days is not None:

--- a/tests/test_tz_utils.py
+++ b/tests/test_tz_utils.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from csp.utils.tz_safe import normalize_df_to_utc_index, UTC
+from csp.utils.tz_safe import normalize_df_to_utc, UTC
 
 
 def test_ensure_utc_index_naive_and_tw():
@@ -10,7 +10,7 @@ def test_ensure_utc_index_naive_and_tw():
         "low": [1, 2],
         "close": [1, 2],
     })
-    out1 = normalize_df_to_utc_index(df_naive, ts_col="timestamp")
+    out1 = normalize_df_to_utc(df_naive)
     assert str(out1.index.tz) == UTC
 
     df_tw = pd.DataFrame({
@@ -20,5 +20,5 @@ def test_ensure_utc_index_naive_and_tw():
         "low": [1, 2],
         "close": [1, 2],
     })
-    out2 = normalize_df_to_utc_index(df_tw, ts_col="timestamp")
+    out2 = normalize_df_to_utc(df_tw)
     assert str(out2.index.tz) == UTC


### PR DESCRIPTION
## Summary
- add safe timezone utilities for Timestamps, indexes, and DataFrames
- normalize DataFrames to UTC immediately after reading CSV files
- switch modules to use new `normalize_df_to_utc` helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b46aab49e8832dbd6419d61ca34c69