### PR TITLE
feat: validate local csvs before fetching data

### DIFF
--- a/csp/utils/validate_data.py
+++ b/csp/utils/validate_data.py
@@ -1,0 +1,80 @@
+import pandas as pd
+import numpy as np
+import sys
+from csp.data.fetcher import fetch_inc, fetch_full
+
+REQUIRED_COLS = ["timestamp", "open", "high", "low", "close", "volume"]
+
+
+def validate_csv(path: str, tail_check: int = 10):
+    """
+    回傳 (ok, reason)
+    ok=True 表示通過；False 時 reason 可能是：
+      - read_fail:... / schema_miss / tz_parse_fail:... / not_sorted / duplicate_ts / nan_tail
+    """
+    try:
+        df = pd.read_csv(path)
+    except Exception as e:
+        return False, f"read_fail:{e}"
+
+    if any(c not in df.columns for c in REQUIRED_COLS):
+        return False, "schema_miss"
+
+    try:
+        ts = pd.to_datetime(df["timestamp"], utc=True)
+    except Exception as e:
+        return False, f"tz_parse_fail:{e}"
+
+    if not ts.is_monotonic_increasing:
+        return False, "not_sorted"
+    if ts.duplicated().any():
+        return False, "duplicate_ts"
+
+    num = df[["open", "high", "low", "close", "volume"]].replace([np.inf, -np.inf], np.nan)
+    if num.tail(tail_check).isna().any().any():
+        return False, "nan_tail"
+
+    return True, "ok"
+
+
+def ensure_data_ready(symbol: str, csv_path: str, fetch_policy: str = "auto", do_validate: bool = True):
+    """Validate local CSV and fetch data as needed.
+
+    Parameters
+    ----------
+    symbol : str
+        Trading pair symbol.
+    csv_path : str
+        Path to local CSV file.
+    fetch_policy : str
+        "auto" | "inc" | "full". When "auto", valid CSV triggers incremental fetch,
+        otherwise a full refetch. "inc"/"full" force respective behavior when
+        validation succeeds. Validation failure always triggers full refetch.
+    do_validate : bool
+        If False, skip validation and just perform fetch according to policy.
+    """
+    if do_validate:
+        ok, reason = validate_csv(csv_path)
+    else:
+        ok, reason = True, "skipped"
+
+    if not ok:
+        print(f"[REPAIR] {symbol} invalid csv ({reason}) -> FULL refetch")
+        res = fetch_full(symbol, csv_path)
+        if not res.get("ok"):
+            print(f"[FATAL] full refetch failed for {symbol}")
+            sys.exit(2)
+        ok2, reason2 = validate_csv(csv_path)
+        if not ok2:
+            print(f"[FATAL] still invalid after full refetch: {symbol} ({reason2})")
+            sys.exit(2)
+        print(f"[VALID] {symbol} ok")
+        return res
+
+    # ok
+    print(f"[VALID] {symbol} ok")
+    if fetch_policy == "full":
+        return fetch_full(symbol, csv_path)
+    else:
+        # inc or auto
+        return fetch_inc(symbol, csv_path)


### PR DESCRIPTION
## Summary
- add `validate_csv` and `ensure_data_ready` helpers
- expose `fetch_inc`/`fetch_full` utilities for incremental and full CSV downloads
- use data validation in backtest and realtime scripts with new CLI flags

## Testing
- `python3 - <<'PY'
from csp.utils.validate_data import validate_csv
print(validate_csv('resources/btc_15m.csv'))
PY` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python3 scripts/realtime_multi.py --cfg csp/configs/strategy.yaml --debug` *(fails: ModuleNotFoundError: No module named 'dateutil')*
- `python3 -m pytest` *(fails: No module named pytest)
- `./audit/audit_data_safety.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b706bb7190832d8eab4f9add2ee64e