### PR TITLE
Harden realtime timezone handling and deployment

### DIFF
--- a/csp/strategy/aggregator.py
+++ b/csp/strategy/aggregator.py
@@ -6,12 +6,7 @@ from dateutil import tz
 from pathlib import Path
 import numpy as np
 from csp.data.binance import fetch_klines_range
-from csp.utils.tz_safe import (
-    normalize_df_to_utc,
-    safe_ts_to_utc,
-    now_utc,
-    floor_utc,
-)
+from csp.utils.timez import ensure_utc_index, to_utc_ts, now_utc, last_closed_15m
 
 
 TZ_TW = tz.gettz("Asia/Taipei")
@@ -112,32 +107,30 @@ def read_or_fetch_latest(
     csv_path: str,
     *,
     interval: str = "15m",
-    now_utc: pd.Timestamp | None = None,
+    now: pd.Timestamp | None = None,
     limit: int = 210,
 ):
     interval_td = pd.to_timedelta(interval)
-    now_ts = now_utc() if now_utc is None else safe_ts_to_utc(now_utc)
-    floor_now = floor_utc(now_ts, interval)
+    now_ts = now_utc() if now is None else to_utc_ts(now)
+    anchor = last_closed_15m(now_ts)
 
     path = Path(csv_path)
     if path.exists():
         df = pd.read_csv(path)
     else:
         df = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
-    df = normalize_df_to_utc(df)
+    df = ensure_utc_index(df, "timestamp")
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
 
-    latest_close = df.index[-1] if not df.empty else pd.NaT
-    latest_open = latest_close - interval_td if pd.notna(latest_close) else pd.NaT
-    bar_close_exact = latest_close
-    match = bool(bar_close_exact == floor_now)
-    is_stale = pd.isna(bar_close_exact) or bar_close_exact < floor_now
+    latest_close = df.index.max() if not df.empty else pd.NaT
+    lag = (anchor - latest_close) if pd.notna(latest_close) else pd.Timedelta.max
+    is_stale = pd.isna(latest_close) or lag >= interval_td
     retried = 0
 
     if is_stale:
         retried = 1
-        end_time = floor_now
+        end_time = anchor
         start_time = end_time - interval_td * max(limit, 210)
         new_df = fetch_klines_range(
             symbol,
@@ -148,21 +141,16 @@ def read_or_fetch_latest(
         df = pd.concat([df, new_df])
         df = df[~df.index.duplicated(keep="last")].sort_index()
         df.reset_index().to_csv(path, index=False)
-        latest_close = df.index[-1] if not df.empty else pd.NaT
-        latest_open = latest_close - interval_td if pd.notna(latest_close) else pd.NaT
-        bar_close_exact = latest_close
-        match = bool(bar_close_exact == floor_now)
-        is_stale = pd.isna(bar_close_exact) or bar_close_exact < floor_now
+        latest_close = df.index.max() if not df.empty else pd.NaT
+        lag = (anchor - latest_close) if pd.notna(latest_close) else pd.Timedelta.max
+        is_stale = pd.isna(latest_close) or lag >= interval_td
 
+    diff_min = lag.total_seconds() / 60 if pd.notna(latest_close) else float("inf")
     print(
-        f"[TIME] now_utc={now_ts.isoformat()} floor_now={floor_now.isoformat()} "
-        f"latest_open={latest_open.isoformat() if pd.notna(latest_open) else 'none'} "
-        f"latest_close={latest_close.isoformat() if pd.notna(latest_close) else 'none'} "
-        f"bar_close_exact={bar_close_exact.isoformat() if pd.notna(bar_close_exact) else 'none'} "
-        f"match={match}"
+        f"[TIME] anchor={anchor.isoformat()} latest_close={latest_close.isoformat() if pd.notna(latest_close) else 'none'} diff_min={diff_min:.2f}"
     )
-    print(f"[FETCH] retried={retried} endTime={floor_now.isoformat()}")
-    return df, floor_now, bar_close_exact, is_stale
+    print(f"[FETCH] retried={retried} endTime={anchor.isoformat()}")
+    return df, anchor, latest_close, is_stale
 
 
 # get_latest_signal（如已存在，請覆蓋為更嚴格版）
@@ -177,18 +165,10 @@ def get_latest_signal(symbol: str, cfg: dict, fresh_min: float = 5.0, *, debug: 
     if not csv_path or not os.path.exists(csv_path):
         return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "no_data"}
 
-    df, floor_now, bar_close_exact, is_stale = read_or_fetch_latest(symbol, csv_path)
+    df, anchor, latest_close, is_stale = read_or_fetch_latest(symbol, csv_path)
+    lag_minutes = (anchor - latest_close).total_seconds() / 60 if pd.notna(latest_close) else float("inf")
+    print(f"[DIAG] latest_ts={latest_close} anchor={anchor} diff_min={lag_minutes:.2f}")
     if is_stale:
-        return {
-            "symbol": symbol,
-            "side": "NONE",
-            "score": 0.0,
-            "reason": "stale_data_after_refresh",
-        }
-
-    now_ts = now_utc()
-    lag_minutes = (now_ts - bar_close_exact).total_seconds() / 60.0
-    if lag_minutes > 15:
         return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "stale_data"}
     if lag_minutes > fresh_min:
         return None
@@ -200,31 +180,33 @@ def get_latest_signal(symbol: str, cfg: dict, fresh_min: float = 5.0, *, debug: 
         files = os.listdir(model_dir) if os.path.exists(model_dir) else []
         print(f"[DEBUG] model_dir={model_dir} files={files} total={len(files)}")
     meta_path = os.path.join(model_dir, "meta.json")
+    if not os.path.exists(model_dir) or not os.listdir(model_dir):
+        return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "no_models_loaded"}
     if not os.path.exists(meta_path):
-        print("[MODELS] loaded=0")
-        print("[FEATURE] last_row_nan_cols=[]")
         return {"symbol": symbol, "side": "NONE", "score": 0.0, "reason": "no_models_loaded"}
     meta = json.load(open(meta_path, "r", encoding="utf-8"))
     feat_cols = meta.get("feature_columns") or []
     if not feat_cols:
-        print("[MODELS] loaded=0")
-        print("[FEATURE] last_row_nan_cols=[]")
         return {"symbol": symbol, "side": "NONE", "score": None, "reason": "no_models_loaded"}
-    for c in feat_cols:
-        if c not in dff.columns:
-            print("[FEATURE] last_row_nan_cols=[]")
-            return {"symbol": symbol, "side": "NONE", "score": None, "reason": "feature_missing"}
-
-    Xall = dff[feat_cols]
-    idx, row = pick_latest_valid_row(Xall, k=3)
-    if row is None:
-        print("[FEATURE] last_row_nan_cols=[]")
-        return {"symbol": symbol, "side": "NONE", "score": None, "reason": "no_valid_features"}
-    X = row.to_frame().T
+    x = dff.iloc[[-1]].replace([np.inf, -np.inf], np.nan).ffill().bfill()
+    x = x.reindex(feat_cols, axis=1)
+    missing = [c for c in feat_cols if c not in dff.columns]
+    if missing:
+        print(f"[DIAG] feature_missing={missing}")
+        return {"symbol": symbol, "side": "NONE", "score": None, "reason": "feature_mismatch"}
+    nan_cols = x.columns[x.iloc[0].isna()].tolist()
+    if nan_cols:
+        print(f"[DIAG] feature_nan_cols={nan_cols}")
+        return {"symbol": symbol, "side": "NONE", "score": None, "reason": "feature_nan"}
 
     m = MultiThresholdClassifier.load(model_dir)
-    print(f"[MODEL] loaded for {symbol} | n_features={len(feat_cols)}")
-    prob_map = m.predict_proba(X)
+    model_files = os.listdir(model_dir)
+    print(f"[DIAG] models_loaded={model_files}")
+    prob_map = m.predict_proba(x)
+    print(f"[DIAG] predict_proba={prob_map}")
+    prob_map = {k: float(v) for k, v in prob_map.items() if v is not None and not pd.isna(v)}
+    if not prob_map:
+        return {"symbol": symbol, "side": "NONE", "score": None, "reason": "empty_or_invalid_inputs"}
     th = cfg.get("strategy", {}).get("enter_threshold", 0.75)
     method = cfg.get("strategy", {}).get("aggregator_method", "max_weighted")
     sig = aggregate_signal(prob_map, enter_threshold=th, method=method)
@@ -235,4 +217,5 @@ def get_latest_signal(symbol: str, cfg: dict, fresh_min: float = 5.0, *, debug: 
     sig["price"] = price
     sig["symbol"] = symbol
     sig["ts"] = now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[DIAG] final side={sig['side']} score={sig.get('score')} reason={sig.get('reason')}")
     return sig

--- a/csp/utils/timez.py
+++ b/csp/utils/timez.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import pandas as pd
+
+UTC = "UTC"
+LOCAL = "Asia/Taipei"
+
+def to_utc_ts(ts: pd.Timestamp | str) -> pd.Timestamp:
+    ts = pd.to_datetime(ts, errors="raise")
+    if ts.tzinfo is None:
+        return ts.tz_localize(LOCAL).tz_convert(UTC)
+    return ts.tz_convert(UTC)
+
+def ensure_utc_index(df: pd.DataFrame, col: str = "timestamp") -> pd.DataFrame:
+    if col in df.columns:
+        ts = pd.to_datetime(df[col], utc=True)
+        df = df.drop(columns=[col]).copy()
+        df.index = ts
+    else:
+        idx = pd.to_datetime(df.index, errors="raise")
+        if getattr(idx, "tz", None) is None:
+            idx = idx.tz_localize(UTC)
+        else:
+            idx = idx.tz_convert(UTC)
+        df = df.copy()
+        df.index = idx
+    df = df[~df.index.duplicated(keep="last")]
+    return df.sort_index()
+
+def now_utc() -> pd.Timestamp:
+    return pd.Timestamp.now(tz=UTC)
+
+def last_closed_15m(now: pd.Timestamp | None = None) -> pd.Timestamp:
+    if now is None:
+        now = now_utc()
+    return now.floor("15min")

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(pwd)"
+TARGET_DIR="/opt/crypto_strategy_project"
+
+echo "[DEPLOY] Sync code to ${TARGET_DIR}"
+sudo mkdir -p "${TARGET_DIR}"
+sudo rsync -a --delete "${REPO_DIR}/" "${TARGET_DIR}/"
+
+if [ -d "${REPO_DIR}/systemd" ]; then
+  echo "[DEPLOY] Install systemd units"
+  for unit in ${REPO_DIR}/systemd/*.service ${REPO_DIR}/systemd/*.timer; do
+    [ -e "$unit" ] || continue
+    sudo cp "$unit" "/etc/systemd/system/$(basename "$unit")"
+  done
+  sudo systemctl daemon-reload
+  sudo systemctl enable trader-once.timer >/dev/null 2>&1 || true
+  sudo systemctl enable trader.timer >/dev/null 2>&1 || true
+fi
+
+sudo systemctl start trader-once.service || true
+
+echo "[DEPLOY] done"

--- a/scripts/predict_and_notify.py
+++ b/scripts/predict_and_notify.py
@@ -9,12 +9,7 @@ import pandas as pd
 from csp.pipeline.realtime_v2 import run_once
 from csp.utils.notifier import notify as base_notify
 from csp.utils.io import load_cfg
-from csp.utils.tz_safe import (
-    normalize_df_to_utc,
-    safe_ts_to_utc,
-    now_utc,
-    floor_utc,
-)
+from csp.utils.timez import ensure_utc_index
 
 
 def notify(message, telegram_cfg, *, score=None, x_last=None, res=None):
@@ -47,7 +42,7 @@ def main():
             raise ValueError("--csv not provided and cfg.io.csv_paths empty")
 
     df = pd.read_csv(csv_path)
-    df = normalize_df_to_utc(df)
+    df = ensure_utc_index(df, "timestamp")
     print(f"[DIAG] df.index.tz={df.index.tz}, head_ts={df.index[:3].tolist()}")
     assert str(df.index.tz) == "UTC", "[DIAG] index not UTC"
 

--- a/scripts/realtime_loop.py
+++ b/scripts/realtime_loop.py
@@ -24,12 +24,7 @@ from csp.utils.notifier import (
 )
 from csp.runtime.exit_watchdog import check_exit_once
 from csp.utils.io import load_cfg
-from csp.utils.tz_safe import (
-    normalize_df_to_utc,
-    safe_ts_to_utc,
-    now_utc,
-    floor_utc,
-)
+# timezone utilities handled within aggregator
 from csp.utils.validate_data import ensure_data_ready
 
 TW = tz.gettz("Asia/Taipei")

--- a/scripts/realtime_multi.py
+++ b/scripts/realtime_multi.py
@@ -11,6 +11,7 @@ TZ_TW = tz.gettz("Asia/Taipei")
 from csp.utils.notifier import notify
 from csp.utils.io import load_cfg
 from csp.utils.validate_data import ensure_data_ready
+from csp.utils.timez import to_utc_ts
 import pandas as pd
 
 
@@ -37,7 +38,7 @@ def main():
         if live_cfg.get("enabled"):
             try:
                 info = ensure_data_ready(sym, csv_path)
-                last_ts = pd.to_datetime(info.get("last_ts"), utc=True)
+                last_ts = to_utc_ts(info.get("last_ts"))
                 print(f"  last closed UTC={last_ts.isoformat()} | TW={(last_ts.tz_convert(TZ_TW)).isoformat()}")
             except Exception as e:
                 print(f"[WARN] data fetch failed for {sym}: {e}")

--- a/systemd/trader-once.service
+++ b/systemd/trader-once.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Crypto Strategy Realtime Loop (15m, one-shot)
+After=network.target
+
+[Service]
+Type=oneshot
+User=deploy
+WorkingDirectory=/opt/crypto_strategy_project
+ExecStart=/bin/bash -lc '. .venv/bin/activate && python scripts/realtime_loop.py --cfg csp/configs/strategy.yaml --delay-sec 15'
+Restart=no
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/trader-once.timer
+++ b/systemd/trader-once.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run trader-once.service every 15 minutes with 15s delay
+
+[Timer]
+OnCalendar=*:00/15
+AccuracySec=1s
+Unit=trader-once.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/trader.service
+++ b/systemd/trader.service
@@ -1,13 +1,15 @@
 [Unit]
-Description=Crypto Strategy Realtime Loop
+Description=Crypto Strategy Long-running Realtime
 After=network.target
 
 [Service]
 Type=simple
+User=deploy
 WorkingDirectory=/opt/crypto_strategy_project
-ExecStartPre=/bin/sleep 15
-ExecStart=/opt/crypto_strategy_project/run_realtime.sh
+ExecStart=/bin/bash -lc '. .venv/bin/activate && python scripts/realtime_loop.py --cfg csp/configs/strategy.yaml --delay-sec 15 --infinite'
 Restart=always
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/trader.timer
+++ b/systemd/trader.timer
@@ -1,11 +1,11 @@
 [Unit]
-Description=Run trader.service every 15 minutes
+Description=Run trader.service on a timer (optional)
 
 [Timer]
-OnCalendar=*:0/15
-Persistent=true
-AccuracySec=1s
+OnBootSec=1min
+OnUnitActiveSec=15min
 Unit=trader.service
+Persistent=true
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add timezone helper for UTC conversions
- improve training and realtime scripts with strict UTC handling and diagnostics
- add systemd units and deployment script for timed realtime loop

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b90364abac832d9251bd6e26eaeb92