### PR TITLE
Improve index reset robustness and diagnostics

### DIFF
--- a/csp/data/fetcher.py
+++ b/csp/data/fetcher.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import pandas as pd
 import requests
+from csp.utils.framefix import safe_reset_index
 
 from csp.utils.tz_safe import (
     normalize_df_to_utc,
@@ -156,7 +157,7 @@ def update_csv_with_latest(
     print(f"[FETCH] {symbol} need={need} appended={appended} last_ts={last_str}")
 
     tmp = path.with_suffix(path.suffix + ".tmp")
-    df.reset_index().to_csv(tmp, index=False)
+    safe_reset_index(df, name="timestamp", overwrite=True).to_csv(tmp, index=False)
     os.replace(tmp, path)
     time.sleep(0.25)
     return df
@@ -191,7 +192,7 @@ def fetch_full(symbol: str, csv_path: str) -> dict:
     df = fetch_klines(symbol, interval=interval, start_ts=start_ts, end_ts=end_ts)
     path = Path(csv_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    df.reset_index().to_csv(path, index=False)
+    safe_reset_index(df, name="timestamp", overwrite=True).to_csv(path, index=False)
     last_ts = df.index[-1].isoformat() if len(df) else "none"
     print(f"[FETCH] {symbol} FULL rows={len(df)} last_ts={last_ts}")
     return {"ok": True, "mode": "full", "rows": int(len(df)), "last_ts": last_ts}

--- a/csp/features/h16.py
+++ b/csp/features/h16.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import pandas as pd
 import numpy as np
+from csp.utils.framefix import safe_reset_index
+from csp.utils.diag import log_diag
 
 """
 h16 特徵（以 15m 基礎 + 4H 聚合）
@@ -82,10 +84,15 @@ def build_features_15m_4h(
     feats = pd.concat(
         [df, h4_to_15[["atr_h4", "rsi_h4", "ema_h4_21", "ema_h4_50"]]],
         axis=1
-    ).reset_index()
+    )
+    feats = safe_reset_index(feats, name="timestamp", overwrite=True)
 
     # 去掉起始 NaN（均線/布林/ATR 等產生的缺值）
-    feats = feats.dropna().reset_index(drop=True)
+    feats = feats.dropna()
+    log_diag(
+        f"about to reset_index: idx.name={feats.index.name}, cols={list(feats.columns)[:8]}... total_cols={len(feats.columns)}"
+    )
+    feats = feats.reset_index(drop=True)
     return feats
 
 def make_labels(df: pd.DataFrame, horizon: int = 16) -> pd.Series:

--- a/csp/strategy/aggregator.py
+++ b/csp/strategy/aggregator.py
@@ -17,6 +17,7 @@ from csp.utils.timez import (
     now_utc,
 )
 from csp.utils.diag import log_diag, log_trace
+from csp.utils.framefix import safe_reset_index
 
 
 TZ_TW = tz.gettz("Asia/Taipei")
@@ -191,7 +192,7 @@ def read_or_fetch_latest(
             )
             df = pd.concat([df, new_df])
             df = df[~df.index.duplicated(keep="last")].sort_index()
-            df.reset_index().to_csv(path, index=False)
+            safe_reset_index(df, name="timestamp", overwrite=True).to_csv(path, index=False)
             latest_close = df.index.max() if not df.empty else pd.NaT
             lag = (anchor - latest_close) if pd.notna(latest_close) else pd.Timedelta.max
             is_stale = pd.isna(latest_close) or lag >= interval_td

--- a/csp/utils/framefix.py
+++ b/csp/utils/framefix.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import pandas as pd
+from csp.utils.diag import log_diag
+
+
+def safe_reset_index(df: pd.DataFrame, name: str = "timestamp", overwrite: bool = True) -> pd.DataFrame:
+    """
+    Reset index into a column with a desired name without triggering
+    'ValueError: cannot insert <name>, already exists'.
+
+    - If the index already has a name and you pass a different 'name',
+      we temporarily set index.name to that 'name'.
+    - If a column with the same 'name' exists:
+        * overwrite=True  -> drop that column first
+        * overwrite=False -> keep it and name the index column '<name>_idx'
+    """
+    d = df.copy()
+    # Decide the target name for the new column coming from the index
+    target = name or (d.index.name if d.index.name is not None else "index")
+
+    # If there is a collision with an existing column name
+    if target in d.columns:
+        if overwrite:
+            log_diag(f"safe_reset_index: dropping existing column '{target}' to avoid collision")
+            d = d.drop(columns=[target])
+        else:
+            target = f"{target}_idx"
+            log_diag(f"safe_reset_index: renaming index column to '{target}' to avoid collision")
+
+    # Set index name and reset
+    d.index = pd.Index(d.index)  # ensure Index object
+    d.index.name = target
+    try:
+        d = d.reset_index()
+    except Exception as e:
+        # Extra diagnostics to help debugging
+        log_diag(f"safe_reset_index FAILED: idx.name={d.index.name}, cols={list(d.columns)}")
+        raise
+    return d

--- a/csp/utils/timez.py
+++ b/csp/utils/timez.py
@@ -26,8 +26,12 @@ def ensure_utc_index(df: pd.DataFrame, col: str = "timestamp") -> pd.DataFrame:
             idx = idx.tz_convert(UTC)
         df = df.copy()
         df.index = idx
-    df = df[~df.index.duplicated(keep="last")]
-    return df.sort_index()
+    df = df[~df.index.duplicated(keep="last")].sort_index()
+    # ensure no extra 'timestamp' column remains and keep neutral index name
+    if col in df.columns:
+        df = df.drop(columns=[col])
+    df.index.name = None
+    return df
 
 def now_utc() -> pd.Timestamp:
     return pd.Timestamp.now(tz=UTC)

--- a/scripts/backtest_multi.py
+++ b/scripts/backtest_multi.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 import requests
+from csp.utils.diag import log_diag
 
 # 依賴 backtest_v2 的核心邏輯
 from csp.backtesting.backtest_v2 import run_backtest_for_symbol
@@ -106,7 +107,11 @@ def append_missing_15m(csv_path: str, symbol: str, end_utc: datetime) -> None:
             break
 
     if rows:
-        df_new = pd.DataFrame(rows).sort_values("timestamp").reset_index(drop=True)
+        df_new = pd.DataFrame(rows).sort_values("timestamp")
+        log_diag(
+            f"about to reset_index: idx.name={df_new.index.name}, cols={list(df_new.columns)[:8]}... total_cols={len(df_new.columns)}"
+        )
+        df_new = df_new.reset_index(drop=True)
         df_old = read_local_csv(csv_path)
         df_all = pd.concat([df_old, df_new], ignore_index=True).drop_duplicates(subset=["timestamp"]).sort_values("timestamp")
         write_local_csv(csv_path, df_all)

--- a/scripts/train_multi_cls.py
+++ b/scripts/train_multi_cls.py
@@ -15,6 +15,7 @@ from csp.utils.tz_safe import (
     now_utc,
     floor_utc,
 )
+from csp.utils.framefix import safe_reset_index
 
 
 def load_csv(csv_path: str, days: int | None = None) -> pd.DataFrame:
@@ -53,7 +54,7 @@ if __name__ == "__main__":
         df_raw = load_csv(csv_path, args.days)
         feat_params = get_symbol_features(cfg, sym)
         feats = build_features_15m_4h(
-            df_raw.reset_index(),
+            safe_reset_index(df_raw, name="timestamp", overwrite=True),
             ema_windows=tuple(feat_params["ema_windows"]),
             rsi_window=feat_params["rsi_window"],
             bb_window=feat_params["bb_window"],


### PR DESCRIPTION
## Summary
- add `safe_reset_index` helper that drops or renames colliding timestamp columns
- replace raw `reset_index` calls in data loading and training utilities with the helper
- log index/column state before remaining `reset_index(drop=True)` operations and neutralize index name in `ensure_utc_index`

## Testing
- `pytest`
- `systemd-run --wait --unit=oneshot-test --collect bash -lc 'cd /workspace/crypto_strategy_project && python scripts/realtime_loop.py --cfg csp/configs/strategy.yaml --delay-sec 0 --once'` *(fails: System has not been booted with systemd as init system (PID 1))*
- `PYTHONPATH=. python scripts/realtime_loop.py --cfg csp/configs/strategy.yaml --delay-sec 0 --once` *(fails: HTTPSConnectionPool(host='api.binance.com', port=443): Max retries exceeded with url: /api/v3/klines?symbol=BTCUSDT&interval=15m&startTime=1756899900000&endTime=1757088900000&limit=1000 (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_68bb0ee8ad88832dae39af4f277ffb82