### PR TITLE
feat: improve realtime model loading and fetching

### DIFF
--- a/csp/configs/strategy.example.models.yaml
+++ b/csp/configs/strategy.example.models.yaml
@@ -1,0 +1,11 @@
+# 只示範結構；把 path 換成你 VM 上實際模型檔案路徑
+models:
+  - name: xgb_main
+    type: xgboost
+    path: /opt/crypto_strategy_project/resources/models/xgb_main.json
+  - name: cat_aux
+    type: catboost
+    path: /opt/crypto_strategy_project/resources/models/cat_aux.cbm
+
+realtime:
+  fetch: csv_only   # live/binance/csv_only/none

--- a/csp/strategy/model_hub.py
+++ b/csp/strategy/model_hub.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import os, sys
+from typing import Dict, Any
+from csp.utils.diag import log_diag
+
+def load_models_from_cfg(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    根據 cfg['models'] 載入模型，回傳 dict。
+    支援最簡版本：只把路徑存在、可讀取當作已載入（若需要，之後可替換成真實的 model.load(...)）。
+    結果為空時不丟例外；上層會用 reason=no_models_loaded 早退。
+    """
+    models = {}
+    models_cfg = (cfg or {}).get("models", [])
+    if not models_cfg:
+        log_diag("model_hub: models list empty in cfg")
+        return models
+
+    for item in models_cfg:
+        name = str(item.get("name") or "").strip()
+        mtype = str(item.get("type") or "").strip().lower()
+        path = str(item.get("path") or "").strip()
+        if not name:
+            log_diag(f"model_hub: skip unnamed model entry: {item}")
+            continue
+        if not path:
+            log_diag(f"model_hub: model '{name}' missing path")
+            continue
+        if not os.path.exists(path):
+            log_diag(f"model_hub: model '{name}' path not found: {path}")
+            continue
+
+        # TODO: 這裡可替換成實際框架的 load(...)，目前先保留路徑與型別
+        models[name] = {"type": mtype, "path": path}
+        log_diag(f"model_hub: loaded '{name}' ({mtype}) from {path}")
+    if not models:
+        log_diag("model_hub: no valid models loaded (all skipped)")
+    return models

--- a/systemd/trader-once.service
+++ b/systemd/trader-once.service
@@ -13,6 +13,7 @@ ExecStart=/opt/crypto_strategy_project/.venv/bin/python /opt/crypto_strategy_pro
 Nice=10
 EnvironmentFile=-/opt/crypto_strategy_project/.env
 Environment=PYTHONUNBUFFERED=1
+# Environment=MODEL_DIR=/opt/crypto_strategy_project/resources/models
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Summary
- add model hub to load models from strategy config
- guard realtime data fetcher and update aggregator anchor handling
- load models in realtime loop and pass through to aggregator
- include sample model config and optional MODEL_DIR environment variable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbdacc2b00832dab5f67663f4c55fa