### PR TITLE
feat: add model loader and absolute resource paths

### DIFF
--- a/csp/configs/strategy.example.yaml
+++ b/csp/configs/strategy.example.yaml
@@ -1,0 +1,12 @@
+# 提供參考，便於配置
+resources_dir: resources
+require_models: false
+
+models:
+  - name: dummy_xgb
+    type: xgboost
+    path: /opt/crypto_strategy_project/resources/models/xgb_main.json
+
+realtime:
+  fetch: csv_only
+  stale_threshold_min: 30

--- a/csp/strategy/model_hub.py
+++ b/csp/strategy/model_hub.py
@@ -1,35 +1,38 @@
 from __future__ import annotations
-import os, sys
-from typing import Dict, Any
+import os
+from typing import Dict, Any, List
 from csp.utils.diag import log_diag
 
+
+def _as_list(v) -> List[dict]:
+    if v is None:
+        return []
+    if isinstance(v, list):
+        return v
+    return [v]
+
+
 def load_models_from_cfg(cfg: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    根據 cfg['models'] 載入模型，回傳 dict。
-    支援最簡版本：只把路徑存在、可讀取當作已載入（若需要，之後可替換成真實的 model.load(...)）。
-    結果為空時不丟例外；上層會用 reason=no_models_loaded 早退。
-    """
-    models = {}
-    models_cfg = (cfg or {}).get("models", [])
-    if not models_cfg:
+    models: Dict[str, Any] = {}
+    items = _as_list((cfg or {}).get("models"))
+    if not items:
         log_diag("model_hub: models list empty in cfg")
         return models
 
-    for item in models_cfg:
+    for item in items:
         name = str(item.get("name") or "").strip()
         mtype = str(item.get("type") or "").strip().lower()
         path = str(item.get("path") or "").strip()
         if not name:
-            log_diag(f"model_hub: skip unnamed model entry: {item}")
+            log_diag(f"model_hub: skip unnamed model: {item}")
             continue
         if not path:
             log_diag(f"model_hub: model '{name}' missing path")
             continue
         if not os.path.exists(path):
-            log_diag(f"model_hub: model '{name}' path not found: {path}")
+            log_diag(f"model_hub: path not found for '{name}': {path}")
             continue
-
-        # TODO: 這裡可替換成實際框架的 load(...)，目前先保留路徑與型別
+        # TODO: replace with actual load; return metadata for now
         models[name] = {"type": mtype, "path": path}
         log_diag(f"model_hub: loaded '{name}' ({mtype}) from {path}")
     if not models:

--- a/csp/utils/paths.py
+++ b/csp/utils/paths.py
@@ -1,0 +1,12 @@
+# NEW utility to resolve absolute resources dir from repo root
+import os
+
+def repo_root() -> str:
+    # assume this file is under csp/utils/; go two levels up
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+def resolve_resources_dir(cfg: dict) -> str:
+    cfg_dir = (cfg or {}).get("resources_dir", "resources")
+    if os.path.isabs(cfg_dir):
+        return cfg_dir
+    return os.path.join(repo_root(), cfg_dir)

--- a/scripts/realtime_loop.py
+++ b/scripts/realtime_loop.py
@@ -36,8 +36,9 @@ if os.environ.get("DIAG_SELFTEST") == "1":
     except Exception as e:
         log_trace("SELFTEST", e)
 
-from csp.strategy.aggregator import get_latest_signal, read_or_fetch_latest
+from csp.strategy import aggregator
 from csp.strategy.model_hub import load_models_from_cfg
+from csp.utils.paths import resolve_resources_dir
 from csp.strategy.position_sizing import (
     blended_sizing, SizingInput, ExchangeRule, kelly_fraction
 )
@@ -158,16 +159,13 @@ def predict_one(symbol: str, df_15m: pd.DataFrame, model, scaler, cfg_path: str 
 
 def process_symbol(symbol: str, cfg: dict, models: dict):
     try:
-        csv_path = cfg["io"]["csv_paths"].get(symbol)
-        if not csv_path or not os.path.exists(csv_path):
-            return {"side": "NONE", "score": 0.0, "reason": "no_data"}
-        res = read_or_fetch_latest(symbol, csv_path, cfg=cfg)
+        res = aggregator.read_or_fetch_latest(symbol, cfg=cfg)
         if isinstance(res, dict):
             return res
-        df, anchor, latest_close, is_stale = res
-        if is_stale:
-            return {"side": "NONE", "score": 0.0, "reason": "stale_data"}
-        sig = get_latest_signal(symbol=symbol, df=df, cfg=cfg, models=models, now_ts=None)
+        df = res
+        sig = aggregator.get_latest_signal(
+            symbol=symbol, df=df, cfg=cfg, models=models, now_ts=None
+        )
         if not sig:
             notify_guard("signal_unavailable", {"symbol": symbol})
             return {"side": "NONE", "score": 0.0, "reason": "signal_unavailable"}
@@ -176,7 +174,11 @@ def process_symbol(symbol: str, cfg: dict, models: dict):
         return sig
     except Exception as e:
         log_trace("LOOP_EXCEPTION", e)
-        return {"side": "NONE", "score": 0.0, "reason": f"LOOP_EXCEPTION:{type(e).__name__}"}
+        return {
+            "side": "NONE",
+            "score": 0.0,
+            "reason": f"LOOP_EXCEPTION:{type(e).__name__}",
+        }
 
 
 def next_quarter_with_delay(now: datetime, delay_sec: int = 15) -> datetime:
@@ -193,19 +195,18 @@ def run_once(cfg: dict | str, delay_sec: int | None = None) -> dict:
     assert isinstance(cfg, dict), f"cfg must be dict, got {type(cfg)}"
     telegram_conf = cfg.get("notify", {}).get("telegram")
     symbols = cfg.get("symbols", [])
-    csv_map = cfg.get("io", {}).get("csv_paths", {})
     models = load_models_from_cfg(cfg)
-    if not models:
-        log_diag(
-            "realtime_loop: models empty -> downstream will return reason=no_models_loaded"
-        )
+    resources_dir = resolve_resources_dir(cfg)
+    log_diag(
+        f"realtime_loop: models_loaded={len(models)} resources_dir={resources_dir}"
+    )
     results = {}
     os.makedirs("logs/diag", exist_ok=True)
 
     for sym in symbols:
-        csv_path = csv_map.get(sym)
+        csv_path = aggregator._csv_path_for_symbol(sym, cfg)
         if not csv_path:
-            print(f"[SKIP] {sym}: No CSV path in config")
+            print(f"[SKIP] {sym}: csv not found under resources_dir")
             continue
         print(f"[REALTIME] {sym} <- {csv_path}")
         try:
@@ -216,7 +217,11 @@ def run_once(cfg: dict | str, delay_sec: int | None = None) -> dict:
             res = process_symbol(sym, cfg, models)
         except Exception as e:
             log_trace("LOOP_EXCEPTION", e)
-            res = {"side": "NONE", "score": 0.0, "reason": f"LOOP_EXCEPTION:{type(e).__name__}"}
+            res = {
+                "side": "NONE",
+                "score": 0.0,
+                "reason": f"LOOP_EXCEPTION:{type(e).__name__}",
+            }
         sig = res if res.get("side") in ("LONG", "SHORT") else None
         if res.get("price") is not None and sig:
             notify_signal(sym, sig, float(res.get("price")), telegram_conf)


### PR DESCRIPTION
## Summary
- add model hub loader with path validation and optional model requirement
- resolve resource paths from repo root and guard CSV/fetcher usage
- log models and resources in realtime loop and respect stale threshold

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbdd83e7cc832d8c95142880710bc5