### PR TITLE
Add CI training and deployment workflow

### DIFF
--- a/.github/workflows/ci_train_and_deploy.yml
+++ b/.github/workflows/ci_train_and_deploy.yml
@@ -1,0 +1,136 @@
+name: CI Train & Deploy
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch: {}
+
+jobs:
+  train:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        symbol: [ BTCUSDT, ETHUSDT, BCHUSDT ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Train model (${{ matrix.symbol }})
+        env:
+          SYMBOL: ${{ matrix.symbol }}
+        run: |
+          mkdir -p models/${SYMBOL}
+          # 依專案實作，若 train_multi.py 支援多幣一起訓練，也可改成單幣模式
+          # 請實作/確認 train_multi.py 支援 --symbols 或 --symbol
+          # 這裡用單幣範例：
+          python scripts/train_multi.py --symbol "${SYMBOL}" --out "models/${SYMBOL}"
+          test -s "models/${SYMBOL}" || (echo "Model output empty for ${SYMBOL}" && exit 1)
+
+      - name: Upload models artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: models-all
+          path: models/
+
+  deploy:
+    needs: [ train ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download models
+        uses: actions/download-artifact@v4
+        with:
+          name: models-all
+          path: models
+
+      - name: Show tree
+        run: |
+          echo "=== models/ tree ==="
+          ls -laR models || true
+
+      - name: Prepare SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -p "${{ secrets.SSH_PORT || 22 }}" "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Rsync code + models to VM
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT || 22 }}
+        run: |
+          set -euo pipefail
+          RSYNC_RSH="ssh -p ${SSH_PORT} -i ~/.ssh/id_rsa -o StrictHostKeyChecking=yes"
+          # 同步整個 repo（包含 models/）
+          # 保留 venv，避免把 venv 搬來搬去；logs 也通常不必要上傳
+          rsync -avz --delete \
+            --exclude ".git" \
+            --exclude ".github" \
+            --exclude ".venv" \
+            --exclude "logs" \
+            -e "${RSYNC_RSH}" ./ "${SSH_USER}@${SSH_HOST}:/opt/crypto_strategy_project/"
+
+      - name: Install systemd units + reload + enable
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT || 22 }}
+        run: |
+          ssh -p "${SSH_PORT}" -i ~/.ssh/id_rsa -o StrictHostKeyChecking=yes "${SSH_USER}@${SSH_HOST}" 'bash -s' <<'REMOTE'
+          set -euo pipefail
+          cd /opt/crypto_strategy_project
+
+          echo "[DEPLOY] Ensure systemd unit files exist in project root"
+          test -f trader-once.service && sudo -n cp trader-once.service /etc/systemd/system/trader-once.service
+          test -f trader-once.timer   && sudo -n cp trader-once.timer   /etc/systemd/system/trader-once.timer
+          test -f trader.service      && sudo -n cp trader.service      /etc/systemd/system/trader.service || true
+          test -f trader.timer        && sudo -n cp trader.timer        /etc/systemd/system/trader.timer   || true
+
+          echo "[DEPLOY] daemon-reload & enable timer"
+          sudo -n systemctl daemon-reload
+          sudo -n systemctl stop trader-once.service || true
+          sudo -n systemctl enable --now trader-once.timer
+          # 立刻跑一次
+          sudo -n systemctl start trader-once.service
+
+          echo "[DEPLOY] show status"
+          sudo -n systemctl status trader-once.timer --no-pager || true
+          sudo -n systemctl status trader-once.service --no-pager || true
+          REMOTE
+
+      - name: Sanity check on VM (status + recent journal)
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT || 22 }}
+        run: |
+          ssh -p "${SSH_PORT}" -i ~/.ssh/id_rsa -o StrictHostKeyChecking=yes "${SSH_USER}@${SSH_HOST}" 'bash -s' <<'REMOTE'
+          set -euo pipefail
+          cd /opt/crypto_strategy_project
+
+          echo
+          echo "== systemctl status (timer/service) =="
+          sudo -n systemctl status trader-once.timer --no-pager || true
+          sudo -n systemctl status trader-once.service --no-pager || true
+
+          echo
+          echo "== recent journal (last 200 lines, last 30 minutes) =="
+          if ! sudo -n journalctl -u trader-once.service --since "-30 min" -o cat | tail -n 200 ; then
+            sudo -n journalctl -u trader-once.service -n 200 -o cat || true
+          fi
+          REMOTE

--- a/csp/configs/strategy.yaml
+++ b/csp/configs/strategy.yaml
@@ -1,120 +1,25 @@
 symbols:
-- BTCUSDT
-- ETHUSDT
-- BCHUSDT
-io:
-  csv_paths:
-    BTCUSDT: resources/btc_15m.csv
-    ETHUSDT: resources/eth_15m.csv
-    BCHUSDT: resources/bch_15m.csv
-  models_dir: models
-  logs_dir: logs
-  position_file: resources/current_position.yaml
-  live_fetch:
-    enabled: true
-    interval: 15m
-    limit: 96
-    api_base: https://api.binance.com
-strategy:
-  enter_threshold: 0.75
-  aggregator_method: "max_weighted"
-  weight_fn: "sqrt"
-model:
-  type: "xgboost"
-  horizons: [2, 4, 8, 16, 48, 192]
-  thresholds: [0.2, 0.5, 1.0, 2.0]
-  calibrate: "isotonic"
-  cv:
-    type: "expanding"
-    n_splits: 5
-    purge_bars: 2
-    embargo_bars: 2
-  out_dir: "models/{SYMBOL}/cls_multi"
-features:
-  prev_high_period: 20
-  prev_low_period: 20
-  bb_window: 24
-  atr_window: 14
-  atr_percentile_window: 100
-  default:
-    ema_windows:
-    - 9
-    - 21
-    - 50
-    h4_rule:
-      enabled: true
-      resample: 4H
-    rsi: {enabled: true, window: 14}
-    bollinger: {enabled: true, window: 20, std: 2.0}
-    atr: {enabled: true, window: 14}
-  per_symbol:
-    BTCUSDT:
-      rsi: {enabled: true, window: 20}
-      bollinger: {enabled: true, window: 24, std: 3.42}
-      atr: {enabled: true, window: 17}
-    ETHUSDT:
-      rsi: {enabled: true, window: 14}
-      bollinger: {enabled: true, window: 20, std: 2.0}
-      atr: {enabled: true, window: 14}
-train:
-  target_horizon_bars: 16
-  label_threshold: 0.0
-  test_size: 0.2
-  random_state: 42
-  xgb:
-    objective: binary:logistic
-    eval_metric: logloss
-    n_estimators: 600
-    max_depth: 6
-    learning_rate: 0.05
-    subsample: 0.9
-    colsample_bytree: 0.9
-execution:
-  long_prob_threshold: 0.62
-  short_prob_threshold: 0.65
-  atr_tp_sl:
-    long:
-      tp_mult: 1.6
-      sl_mult: 1.0
-    short:
-      tp_mult: 1.2
-      sl_mult: 0.8
-  max_holding_minutes: 240
-  entry_zone:
-    enabled: true
-    method: atr_discount
-    lookahead_bars: 16
-    long_x: 0.5
-    short_x: 0.5
-risk:
-  take_profit_ratio: 0.05
-  stop_loss_ratio: 0.02
-  max_holding_minutes: 240
-  flip_threshold: 0.6
-position_sizing:
-  mode: "hybrid"
-  risk_per_trade: 0.01
-  atr_k: 1.5
-  kelly_coef: 0.5
-  kelly_floor: -0.5
-  kelly_cap: 1.0
-  default_win_rate: 0.6
-  exchange_rule:
-    min_qty: 0.0001
-    qty_step: 0.0001
-    min_notional: 10
-    max_leverage: 10
-notify:
-  telegram:
-    enabled: true
-    bot_token_env: BOT_TOKEN
-    chat_id_env: CHAT_ID
-    bot_token: 7978688690:AAEYbCQMqoyCskxzms7gK-Moh1eYhF4X0rs
-    chat_id: '-4949591915'
-backtest:
-  initial_capital: 10000.0
-  risk_per_trade: 0.007
-  fee_rate: 0.0004
-  slippage: 0.0002
-entry_filter:
-  cooldown_bars: 4
+  - BTCUSDT
+  - ETHUSDT
+  - BCHUSDT
+
+# 先用本地 CSV（resources/*_15m.csv）與已訓練模型
+fetch:
+  mode: csv_only        # csv_only | none | binance
+  resources_dir: /opt/crypto_strategy_project/resources
+
+models:
+  BTCUSDT:
+    dir: /opt/crypto_strategy_project/models/BTCUSDT
+  ETHUSDT:
+    dir: /opt/crypto_strategy_project/models/ETHUSDT
+  BCHUSDT:
+    dir: /opt/crypto_strategy_project/models/BCHUSDT
+
+realtime:
+  require_models: true
+  # 若沒有模型就直接給 no_models_loaded（避免 score=nan）
+
+logging:
+  level: INFO
+  diag: true

--- a/scripts/train_multi.py
+++ b/scripts/train_multi.py
@@ -7,18 +7,29 @@ from csp.utils.io import load_cfg
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--cfg", default="csp/configs/strategy.yaml")
+    ap.add_argument("--symbol", help="train single symbol")
+    ap.add_argument("--symbols", help="comma separated symbols")
+    ap.add_argument("--out", help="output directory when training single symbol")
     args = ap.parse_args()
 
     cfg = load_cfg(args.cfg)
     csv_map = cfg["io"]["csv_paths"]
     base_models = Path(cfg["io"]["models_dir"])
 
-    for sym in cfg["symbols"]:
+    if args.symbol:
+        symbols = [args.symbol]
+    elif args.symbols:
+        symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    else:
+        symbols = cfg["symbols"]
+
+    for sym in symbols:
         csv_path = csv_map.get(sym)
         if not csv_path:
             print(f"[SKIP] {sym}: no csv path")
             continue
-        out_dir = base_models / sym
+
+        out_dir = Path(args.out) if args.out and args.symbol else base_models / sym
         out_dir.mkdir(parents=True, exist_ok=True)
         print(f"[TRAIN] {sym} <- {csv_path}  -> {out_dir}")
         res = train(csv_path, cfg, models_dir_override=str(out_dir), symbol=sym)
@@ -27,3 +38,7 @@ if __name__ == "__main__":
             print(f"[INFO] {sym} positive ratio={pr:.4f}")
         if res.get("warning"):
             print(f"[WARN] {sym}: {res['warning']}")
+
+        # ensure output is not empty
+        if not any(out_dir.iterdir()):
+            raise SystemExit(f"Model output empty for {sym}")

--- a/trader-once.service
+++ b/trader-once.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Crypto Strategy Realtime Once (venv)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/crypto_strategy_project
+Environment="PYTHONUNBUFFERED=1"
+# 若 VM 沒建 venv，第一次建一個；有就跳過
+ExecStartPre=/usr/bin/bash -lc 'test -d .venv || python3 -m venv .venv && . .venv/bin/activate && pip install -U pip && pip install -r requirements.txt'
+# 清除 __pycache__
+ExecStartPre=/usr/bin/find /opt/crypto_strategy_project -name __pycache__ -type d -exec rm -rf {} +
+# 執行一次
+ExecStart=/opt/crypto_strategy_project/.venv/bin/python /opt/crypto_strategy_project/scripts/realtime_loop.py --cfg /opt/crypto_strategy_project/csp/configs/strategy.yaml --delay-sec 15 --once
+Restart=no
+User=%i
+# 若不使用 user@ 服務，移除 User= 這行或改為實際帳號
+
+[Install]
+WantedBy=multi-user.target

--- a/trader-once.timer
+++ b/trader-once.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run trader-once every 15 minutes + 15 seconds
+
+[Timer]
+OnCalendar=*:0/15:15
+Persistent=true
+Unit=trader-once.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add CI workflow that trains per-symbol models and deploys with systemd units
- move systemd `trader-once` unit files to repo root
- simplify strategy config to use pre-trained models and CSV resources
- extend train_multi script with symbol selection and output check

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc2587f838832d999eee447267e322