### PR TITLE
Add Binance public data fetching and refresh stale CSVs

### DIFF
--- a/csp/configs/strategy.yaml
+++ b/csp/configs/strategy.yaml
@@ -2,6 +2,21 @@ symbols:
   - BTCUSDT
   - ETHUSDT
   - BCHUSDT
+# 自動抓取最新 K 線資料的設定
+fetch:
+  mode: public       # public / csv_only / none
+  source: binance_public
+  base_url: "https://api.binance.com"
+  interval: "15m"
+  batch_limit: 500   # 每次抓取蠟燭數（Binance 上限 1000；500 足夠且較穩定）
+  max_retries: 3
+  retry_sleep_sec: 1.0
+
+# 執行時相關參數
+runtime:
+  require_models: true
+  notify:
+    telegram: false
 
 # 供訓練腳本使用的輸入/輸出路徑
 io:
@@ -11,17 +26,17 @@ io:
     BCHUSDT: resources/bch_15m.csv
   models_dir: models
 
+# 模型相關設定
 models:
   use_manifest: true
   manifest_path: models/manifest.json
   globs:
     - "models/*/model.pkl"
 
-realtime:
-  require_models: true
-  fetch_mode: "csv_only_or_none"
-  resources_dir: "resources"
+# 資源檔案所在資料夾
+resources_dir: resources
 
+# 日誌設定
 logging:
   level: INFO
   diag: true

--- a/csp/data/binance_public.py
+++ b/csp/data/binance_public.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import time
+from typing import Optional, List, Tuple
+import requests
+import pandas as pd
+
+def _to_millis(ts) -> int:
+    """接受 pandas Timestamp/str/int，轉成毫秒 UNIX。"""
+    if ts is None:
+        return None
+    if isinstance(ts, (int, float)):
+        return int(ts)
+    # pandas.Timestamp 或可被 pandas 解析的字串
+    return int(pd.Timestamp(ts, tz="UTC").value // 10**6)
+
+def fetch_klines(
+    symbol: str,
+    interval: str,
+    end_ts_utc,                     # pandas.Timestamp/str/int
+    *,
+    base_url: str = "https://api.binance.com",
+    limit: int = 500,
+    session: Optional[requests.Session] = None,
+) -> pd.DataFrame:
+    """
+    透過 Binance 公開 API 取得最多 `limit` 根 K 線（以 endTime 截止，往回取）。
+    免金鑰、只讀公開端點。
+    回傳 DataFrame(index=close_time[ns, tz=UTC], columns=[open,high,low,close,volume]).
+    """
+    end_ms = _to_millis(end_ts_utc)
+    params = {
+        "symbol": symbol,
+        "interval": interval,
+        "limit": min(max(int(limit), 1), 1000),
+    }
+    if end_ms:
+        params["endTime"] = end_ms
+
+    s = session or requests.Session()
+    url = f"{base_url}/api/v3/klines"
+    resp = s.get(url, params=params, timeout=15)
+    resp.raise_for_status()
+    raw = resp.json()  # list of lists
+
+    if not raw:
+        return pd.DataFrame(
+            columns=["open","high","low","close","volume","open_time","close_time"]
+        ).set_index(pd.DatetimeIndex([], tz="UTC"))
+
+    # Binance kline fields:
+    # 0 openTime,1 open,2 high,3 low,4 close,5 volume,6 closeTime,7 quoteAssetVolume,
+    # 8 numberOfTrades,9 takerBuyBaseVolume,10 takerBuyQuoteVolume,11 ignore
+    rows = []
+    for r in raw:
+        rows.append({
+            "open_time":  pd.to_datetime(r[0], unit="ms", utc=True),
+            "open":       float(r[1]),
+            "high":       float(r[2]),
+            "low":        float(r[3]),
+            "close":      float(r[4]),
+            "volume":     float(r[5]),
+            "close_time": pd.to_datetime(r[6], unit="ms", utc=True),
+        })
+    df = pd.DataFrame(rows)
+    df = df.set_index("close_time").sort_index()
+    df.index.name = None
+    return df[["open","high","low","close","volume","open_time"]]

--- a/csp/data/feed.py
+++ b/csp/data/feed.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Optional, Callable
+import os
+import pandas as pd
+import numpy as np
+import logging
+import time
+
+from . import binance_public
+
+log = logging.getLogger(__name__)
+
+
+def _get_fetch_fn(cfg) -> Optional[Callable]:
+    mode = (cfg.get("fetch", {}) or {}).get("mode", "csv_only")
+    if mode in ("none", "csv_only", None):
+        log.debug("fetch disabled (csv_only/none)")
+        return None
+    if mode == "public":
+        fcfg = cfg.get("fetch", {}) or {}
+        base_url = fcfg.get("base_url", "https://api.binance.com")
+        interval = fcfg.get("interval", "15m")
+        batch_limit = int(fcfg.get("batch_limit", 500))
+        def _fn(symbol: str, end_ts_utc):
+            return binance_public.fetch_klines(
+                symbol=symbol,
+                interval=interval,
+                end_ts_utc=end_ts_utc,
+                base_url=base_url,
+                limit=batch_limit,
+            )
+        return _fn
+    log.warning("unknown fetch.mode=%s -> treat as csv_only", mode)
+    return None
+
+
+def read_or_fetch_latest(cfg, symbol: str, csv_path: str, now_ts_in=None):
+    """
+    讀取本地 CSV，若資料過舊且允許，透過公開 API 補足至接近 now_ts。
+    回傳：(df, latest_close_ts_utc)
+    """
+    # 讀 CSV
+    if not os.path.exists(csv_path):
+        raise FileNotFoundError(csv_path)
+    df = pd.read_csv(csv_path)
+    if df.empty:
+        df = pd.DataFrame(columns=["timestamp","open","high","low","close","volume"])
+
+    # index 統一成 UTC
+    if "timestamp" in df.columns:
+        ts = pd.to_datetime(df["timestamp"], utc=True)
+        df = df.drop(columns=[c for c in ("timestamp",) if c in df.columns])
+        df.index = ts
+    else:
+        df.index = pd.to_datetime(df.index, utc=True)
+    df.index.name = None
+
+    now_ts_utc = pd.Timestamp.utcnow() if now_ts_in is None else pd.Timestamp(now_ts_in, tz="UTC")
+    latest_close = df.index.max()
+
+    fetch_fn = _get_fetch_fn(cfg)
+    if fetch_fn is None:
+        log.info("[DIAG] %s: fetch disabled (csv_only/none) -> use local CSV only", symbol)
+        return df, latest_close
+
+    # 若資料過舊，嘗試補資料
+    anchor = now_ts_utc.floor("15min")
+    diff_min = (anchor - latest_close).total_seconds() / 60.0
+    if diff_min <= 0.0:
+        return df, latest_close
+
+    fcfg = cfg.get("fetch", {}) or {}
+    max_retries = int(fcfg.get("max_retries", 3))
+    retry_sleep = float(fcfg.get("retry_sleep_sec", 1.0))
+
+    tries = 0
+    cur_latest = latest_close
+    appended_frames = []
+
+    while tries <= max_retries and cur_latest < anchor:
+        tries += 1
+        log.info("[FETCH] %s retried=%d endTime=%s", symbol, tries-1, anchor.isoformat())
+        fetched = fetch_fn(symbol, end_ts_utc=anchor)
+        if fetched is None or fetched.empty:
+            time.sleep(retry_sleep)
+            continue
+        # 只保留新於現有 latest 的資料
+        fetched = fetched[fetched.index > cur_latest]
+        if fetched.empty:
+            time.sleep(retry_sleep)
+            continue
+        appended_frames.append(fetched)
+        cur_latest = fetched.index.max()
+        # 下一輪以更靠近 anchor 的截止時間再抓一次（或結束）
+        anchor = cur_latest
+
+    if appended_frames:
+        add_df = pd.concat(appended_frames, axis=0).sort_index()
+        keep_cols = [c for c in ("open","high","low","close","volume") if c in add_df.columns]
+        add_df = add_df[keep_cols]
+        df = pd.concat([df, add_df], axis=0).sort_index()
+        df = df[~df.index.duplicated(keep="last")]
+        out = df.copy()
+        out.insert(0, "timestamp", out.index)
+        out.to_csv(csv_path, index=False)
+        latest_close = df.index.max()
+        log.info("[UPDATE] %s CSV appended: +%d rows; latest=%s", symbol, len(add_df), latest_close.isoformat())
+    else:
+        log.warning("[STALE] %s: anchor=%s latest_close=%s diff_min=%.2f (fetch tried, no new rows)",
+                    symbol, anchor.isoformat(), latest_close.isoformat(), diff_min)
+
+    return df, latest_close


### PR DESCRIPTION
## Summary
- add `binance_public` module to retrieve candles via public Binance API
- extend data feed to backfill stale CSVs and persist updates
- streamline realtime loop to use new feed and report stale data more clearly
- include fetch/runtime settings in default strategy config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c042951180832d8e5a8d9dca8876df