### PR TITLE
Add public Binance backfill and network-ready service

### DIFF
--- a/csp/configs/strategy.yaml
+++ b/csp/configs/strategy.yaml
@@ -4,13 +4,15 @@ symbols:
   - BCHUSDT
 # 自動抓取最新 K 線資料的設定
 fetch:
-  mode: public       # public / csv_only / none
+  mode: public_binance       # csv_only / none / public_binance
   source: binance_public
   base_url: "https://api.binance.com"
   interval: "15m"
   batch_limit: 500   # 每次抓取蠟燭數（Binance 上限 1000；500 足夠且較穩定）
   max_retries: 3
   retry_sleep_sec: 1.0
+  max_backfill_minutes: 360  # 一次最多補這麼多分鐘的缺口
+  writeback_csv: true        # 抓到新 K 線就寫回 CSV
 
 # 執行時相關參數
 runtime:

--- a/csp/data/feed.py
+++ b/csp/data/feed.py
@@ -17,7 +17,7 @@ def _get_fetch_fn(cfg) -> Optional[Callable]:
     if mode in ("none", "csv_only", None):
         log.debug("fetch disabled (csv_only/none)")
         return None
-    if mode == "public":
+    if mode in ("public", "public_binance"):
         fcfg = cfg.get("fetch", {}) or {}
         base_url = fcfg.get("base_url", "https://api.binance.com")
         interval = fcfg.get("interval", "15m")

--- a/csp/data/public_klines.py
+++ b/csp/data/public_klines.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import List
+
+import pandas as pd
+import requests
+
+
+INTERVAL_MAP = {
+    "1m": 60,
+    "3m": 180,
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "2h": 7200,
+    "4h": 14400,
+}
+
+
+def _to_millis(ts: dt.datetime) -> int:
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=dt.timezone.utc)
+    return int(ts.timestamp() * 1000)
+
+
+def fetch_binance_klines_public(
+    symbol: str,
+    start_time_utc: dt.datetime,
+    end_time_utc: dt.datetime,
+    interval: str = "15m",
+    api_base: str = "https://api.binance.com",
+    timeout: float = 10.0,
+    limit: int = 1000,
+) -> pd.DataFrame:
+    """Fetch klines from Binance public endpoint without API key.
+
+    Returns a DataFrame with columns [open, high, low, close, volume] indexed by
+    UTC timestamps.
+    """
+
+    if interval not in INTERVAL_MAP:
+        raise ValueError(f"Unsupported interval: {interval}")
+
+    url = f"{api_base}/api/v3/klines"
+    st = start_time_utc
+    frames: List[pd.DataFrame] = []
+    step = dt.timedelta(seconds=INTERVAL_MAP[interval] * (limit - 1))
+
+    while st < end_time_utc:
+        en = min(st + step, end_time_utc)
+        params = {
+            "symbol": symbol,
+            "interval": interval,
+            "startTime": _to_millis(st),
+            "endTime": _to_millis(en),
+            "limit": limit,
+        }
+        r = requests.get(url, params=params, timeout=timeout)
+        r.raise_for_status()
+        raw = r.json()
+        if not raw:
+            break
+        df = pd.DataFrame(
+            raw,
+            columns=[
+                "open_time",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "_ct1",
+                "_ct2",
+                "_ct3",
+                "_ct4",
+                "_ct5",
+                "_ct6",
+            ],
+        )
+        df = df[["open_time", "open", "high", "low", "close", "volume"]].copy()
+        df["timestamp"] = pd.to_datetime(df["open_time"], unit="ms", utc=True)
+        for c in ["open", "high", "low", "close", "volume"]:
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.drop(columns=["open_time"]).set_index("timestamp").sort_index()
+        frames.append(df)
+        st = (
+            df.index[-1].to_pydatetime().replace(tzinfo=dt.timezone.utc)
+            + dt.timedelta(seconds=INTERVAL_MAP[interval])
+        )
+
+    if not frames:
+        return pd.DataFrame(
+            columns=["open", "high", "low", "close", "volume"],
+            dtype="float64",
+        )
+
+    out = pd.concat(frames).sort_index()
+    out = out[~out.index.duplicated(keep="last")]
+    return out
+

--- a/systemd/trader-once.service
+++ b/systemd/trader-once.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Crypto Strategy Realtime Once (venv)
 After=network-online.target
+Wants=network-online.target
 
 [Service]
-Type=simple
+Type=oneshot
 WorkingDirectory=/opt/crypto_strategy_project
 ExecStartPre=/usr/bin/find /opt/crypto_strategy_project -name __pycache__ -type d -exec rm -rf {} +
 ExecStart=/opt/crypto_strategy_project/.venv/bin/python /opt/crypto_strategy_project/scripts/realtime_loop.py \


### PR DESCRIPTION
## Summary
- Allow fetching latest bars via Binance public API and write updated CSVs
- Enable `public_binance` mode in strategy config
- Ensure systemd trader service waits for networking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05c6d58b4832d9da01c7677da890a