### PR TITLE
Add build metadata, timezone safety, and deployment utilities

### DIFF
--- a/scripts/deploy_release.sh
+++ b/scripts/deploy_release.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <ssh_target>  # e.g. ubuntu@trader-1"
+  exit 1
+fi
+
+HOST="$1"
+BASE="/opt/crypto_strategy_project"
+STAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+SHA="$(git rev-parse --short=8 HEAD)"
+REL_DIR="${BASE}/releases/${STAMP}_${SHA}"
+
+ssh "$HOST" "mkdir -p '$REL_DIR'"
+rsync -a --delete --exclude '.venv' ./ "$HOST:$REL_DIR/"
+ssh "$HOST" "cd '$REL_DIR' && ${BASE}/.venv/bin/pip install -r requirements.txt"
+ssh "$HOST" "find '$REL_DIR' -name '__pycache__' -type d -exec rm -rf {} +; find '$REL_DIR' -name '*.pyc' -delete"
+ssh "$HOST" "ln -sfn '$REL_DIR' ${BASE}/current"
+ssh "$HOST" "sudo systemctl daemon-reload && sudo systemctl restart trader-once.timer"
+echo "Deployed to $HOST  build=${SHA}  at ${REL_DIR}"

--- a/scripts/self_check.py
+++ b/scripts/self_check.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import json, hashlib, inspect
+import csp
+
+root = Path(__file__).resolve().parents[1]
+app = root / "scripts" / "realtime_loop.py"
+sha8 = hashlib.sha1(app.read_bytes()).hexdigest()[:8]
+try:
+    rel = json.loads((root/"RELEASE.json").read_text())
+    build = (rel.get("sha") or sha8)[:8]
+    branch = rel.get("branch") or "unknown"
+    built_at = rel.get("built_at") or "unknown"
+except Exception:
+    build, branch, built_at = sha8, "unknown", "unknown"
+
+print("[SELF-CHECK]")
+print("root =", root)
+print("build =", build, "file_sha8 =", sha8, "branch =", branch, "built_at =", built_at)
+print("csp_module_path =", inspect.getfile(csp))


### PR DESCRIPTION
## Summary
- Print build banner with commit info and module paths on realtime loop start
- Normalize timestamps with `ensure_utc_index` and include build tag in notifications
- Add self-check and release deployment scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1d12bb120832daa77df98cb9d8f7e