### PR TITLE
Load Telegram secrets from env file and restart timer

### DIFF
--- a/.github/workflows/train-and-deploy.yml
+++ b/.github/workflows/train-and-deploy.yml
@@ -87,61 +87,63 @@ jobs:
           RSYNC_FLAGS="-avz --delete --exclude .git --exclude .github"
           rsync $RSYNC_FLAGS ./ "${SSH_USER}@${SSH_HOST}:/home/${SSH_USER}/repo_tmp/"
 
-      - name: Deploy to VM
+      - name: Deploy to VM and run once
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID:   ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
-          set -euo pipefail
-          ssh -o StrictHostKeyChecking=yes "${SSH_USER}@${SSH_HOST}" 'bash -s' <<'REMOTE'
-          set -euo pipefail
-          SRC="/home/$USER/repo_tmp"
-          DST="/opt/crypto_strategy_project"
+          ssh -o StrictHostKeyChecking=yes "${SSH_USER}@${SSH_HOST}" \
+            "TELEGRAM_BOT_TOKEN='${TELEGRAM_BOT_TOKEN}' TELEGRAM_CHAT_ID='${TELEGRAM_CHAT_ID}' bash -s" <<'REMOTE'
+            set -euo pipefail
+            SRC="/home/$USER/repo_tmp"
+            DST="/opt/crypto_strategy_project"
 
-          echo "[DEPLOY] Sync code (including models/) to ${DST}"
-          sudo -n rsync -a --delete "${SRC}/" "${DST}/"
+            echo "[DEPLOY] Sync code (including models/) to ${DST}"
+            sudo -n rsync -a --delete "${SRC}/" "${DST}/"
 
-          echo "[DEPLOY] Ensure venv"
-          if [ ! -x "${DST}/.venv/bin/python" ]; then
-            sudo -n python3 -m venv "${DST}/.venv"
-          fi
-          sudo -n bash -lc "${DST}/.venv/bin/pip install --upgrade pip && \
-                            [ -f ${DST}/requirements.txt ] && ${DST}/.venv/bin/pip install -r ${DST}/requirements.txt || true"
-
-          echo "[DEPLOY] Install systemd units"
-          sudo -n cp "${DST}/systemd/trader-once.service" /etc/systemd/system/trader-once.service
-          sudo -n cp "${DST}/systemd/trader-once.timer"   /etc/systemd/system/trader-once.timer
-          sudo -n systemctl daemon-reload
-          sudo -n systemctl enable --now trader-once.timer
-
-          echo "[DEPLOY] Prepare notify env (Telegram)"
-          sudo -n install -d -m 0755 /etc/crypto_strategy_project
-          if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
-            sudo -n bash -lc 'cat > /etc/crypto_strategy_project/notify.env <<EOF
-TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
-TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
+            echo "[DEPLOY] Provision env for systemd (/etc/crypto_strategy_project.env)"
+            if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+              sudo -n bash -lc 'umask 077; cat > /etc/crypto_strategy_project.env <<EOF
+TELEGRAM_BOT_TOKEN='"$TELEGRAM_BOT_TOKEN"'
+TELEGRAM_CHAT_ID='"$TELEGRAM_CHAT_ID"'
 EOF'
-            sudo -n chmod 0640 /etc/crypto_strategy_project/notify.env
-            sudo -n chown root:root /etc/crypto_strategy_project/notify.env
-            echo "[DEPLOY] Wrote /etc/crypto_strategy_project/notify.env"
-          else
-            echo "[DEPLOY] TELEGRAM_* secrets missing – skip notify.env"
-          fi
+              echo "[DEPLOY] Wrote /etc/crypto_strategy_project.env"
+            else
+              echo "[DEPLOY] TELEGRAM_* secrets missing; skipping env file"
+            fi
 
-          echo "[DEPLOY] Restart timer & run once"
-          sudo -n systemctl restart trader-once.timer
-          sudo -n systemctl stop trader-once.service || true
-          sudo -n systemctl start trader-once.service
+            echo "[DEPLOY] Ensure venv"
+            if [ ! -x "${DST}/.venv/bin/python" ]; then
+              sudo -n python3 -m venv "${DST}/.venv"
+            fi
+            sudo -n bash -lc "${DST}/.venv/bin/pip install --upgrade pip && \
+                              [ -f ${DST}/requirements.txt ] && ${DST}/.venv/bin/pip install -r ${DST}/requirements.txt || true"
 
-          echo "[DEPLOY] Status"
-          sudo -n systemctl status trader-once.timer   --no-pager || true
-          sudo -n systemctl status trader-once.service --no-pager || true
-          sudo -n systemctl list-timers --all | grep -i trader-once || true
+            echo "[DEPLOY] Install systemd units"
+            sudo -n cp "${DST}/systemd/trader-once.service" /etc/systemd/system/trader-once.service
+            sudo -n cp "${DST}/systemd/trader-once.timer"   /etc/systemd/system/trader-once.timer
+            sudo -n systemctl daemon-reload
+            sudo -n systemctl enable --now trader-once.timer
+            # 確保任何 timer 變更都即時套用（冪等）
+            sudo -n systemctl restart trader-once.timer
+            sudo -n systemctl stop trader-once.service || true
 
-          echo "== recent journal (last 200 lines, last 30 minutes) =="
-          if ! sudo -n journalctl -u trader-once.service --since "-30 min" -o cat | tail -n 200 ; then
-            sudo -n journalctl -u trader-once.service -n 200 -o cat || true
-          fi
+            echo "[DEPLOY] One-shot run"
+            sudo -n systemctl start trader-once.service
+
+            echo "[DEPLOY] Status"
+            sudo -n systemctl status trader-once.timer   --no-pager || true
+            sudo -n systemctl status trader-once.service --no-pager || true
+            # 額外可觀察點：下一次觸發時間（CI log 中確認排程）
+            sudo -n systemctl list-timers --all | grep -i trader-once || true
+
+            echo "== recent journal (last 200 lines, last 30 minutes) =="
+            if ! sudo -n journalctl -u trader-once.service --since "-30 min" -o cat | tail -n 200 ; then
+              sudo -n journalctl -u trader-once.service -n 200 -o cat || true
+            fi
+
+            echo "== models on VM =="
+            sudo -n bash -lc "find ${DST}/models -maxdepth 2 -type f | sort || true"
           REMOTE

--- a/systemd/trader-once.service
+++ b/systemd/trader-once.service
@@ -1,11 +1,15 @@
 [Unit]
 Description=Crypto Strategy Realtime Once (venv)
-After=network-online.target
 Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=oneshot
 WorkingDirectory=/opt/crypto_strategy_project
+# 可選：若你的 daemon 以非 root 執行，請改成對應帳號
+#User=ubuntu
+# 從檔案注入 Telegram 等機密（不存在也不致命）
+EnvironmentFile=-/etc/crypto_strategy_project.env
 Environment=VIRTUAL_ENV=/opt/crypto_strategy_project/.venv
 Environment=PATH=/opt/crypto_strategy_project/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
- Inject optional /etc/crypto_strategy_project.env into trader-once service for Telegram secrets
- Write TELEGRAM_* secrets on deploy and restart timer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c41c8984a8832d8616121f1d14dce3