### PR TITLE
Refactor deployment workflow for env secrets

### DIFF
--- a/.github/workflows/train-and-deploy.yml
+++ b/.github/workflows/train-and-deploy.yml
@@ -87,63 +87,53 @@ jobs:
           RSYNC_FLAGS="-avz --delete --exclude .git --exclude .github"
           rsync $RSYNC_FLAGS ./ "${SSH_USER}@${SSH_HOST}:/home/${SSH_USER}/repo_tmp/"
 
-      - name: Deploy to VM and run once
+      - name: Deploy to VM (sync + env + systemd)
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
-          ssh -o StrictHostKeyChecking=yes "${SSH_USER}@${SSH_HOST}" \
-            "TELEGRAM_BOT_TOKEN='${TELEGRAM_BOT_TOKEN}' TELEGRAM_CHAT_ID='${TELEGRAM_CHAT_ID}' bash -s" <<'REMOTE'
-            set -euo pipefail
-            SRC="/home/$USER/repo_tmp"
-            DST="/opt/crypto_strategy_project"
+          set -euo pipefail
+          # 把 Secrets 綁在 ssh 前綴，讓「遠端 shell」拿得到
+          ssh -o StrictHostKeyChecking=yes "$SSH_USER@$SSH_HOST" TELEGRAM_BOT_TOKEN='${{ secrets.TELEGRAM_BOT_TOKEN }}' TELEGRAM_CHAT_ID='${{ secrets.TELEGRAM_CHAT_ID }}' bash -s <<'REMOTE'
+          set -euo pipefail
 
-            echo "[DEPLOY] Sync code (including models/) to ${DST}"
-            sudo -n rsync -a --delete "${SRC}/" "${DST}/"
+          SRC="/home/$USER/repo_tmp"
+          DST="/opt/crypto_strategy_project"
 
-            echo "[DEPLOY] Provision env for systemd (/etc/crypto_strategy_project.env)"
-            if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
-              sudo -n bash -lc 'umask 077; cat > /etc/crypto_strategy_project.env <<EOF
-              TELEGRAM_BOT_TOKEN='"$TELEGRAM_BOT_TOKEN"'
-              TELEGRAM_CHAT_ID='"$TELEGRAM_CHAT_ID"'
-              EOF'
-              echo "[DEPLOY] Wrote /etc/crypto_strategy_project.env"
-            else
-              echo "[DEPLOY] TELEGRAM_* secrets missing; skipping env file"
-            fi
+          echo "[DEPLOY] Sync code (including models/) to ${DST}"
+          sudo -n rsync -a --delete "${SRC}/" "${DST}/"
 
-            echo "[DEPLOY] Ensure venv"
-            if [ ! -x "${DST}/.venv/bin/python" ]; then
-              sudo -n python3 -m venv "${DST}/.venv"
-            fi
-            sudo -n bash -lc "${DST}/.venv/bin/pip install --upgrade pip && \
-                              [ -f ${DST}/requirements.txt ] && ${DST}/.venv/bin/pip install -r ${DST}/requirements.txt || true"
+          echo "[DEPLOY] Provision env for systemd (/etc/crypto_strategy_project.env)"
+          sudo -n install -m 600 -o root -g root /dev/null /etc/crypto_strategy_project.env
+          # 用 printf + tee，避免 heredoc 展開/縮排陷阱
+          printf 'TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_CHAT_ID=%s\n' "$TELEGRAM_BOT_TOKEN" "$TELEGRAM_CHAT_ID" | sudo -n tee /etc/crypto_strategy_project.env >/dev/null
+          echo "[DEPLOY] Wrote /etc/crypto_strategy_project.env"
 
-            echo "[DEPLOY] Install systemd units"
-            sudo -n cp "${DST}/systemd/trader-once.service" /etc/systemd/system/trader-once.service
-            sudo -n cp "${DST}/systemd/trader-once.timer"   /etc/systemd/system/trader-once.timer
-            sudo -n systemctl daemon-reload
-            sudo -n systemctl enable --now trader-once.timer
-            # 確保任何 timer 變更都即時套用（冪等）
-            sudo -n systemctl restart trader-once.timer
-            sudo -n systemctl stop trader-once.service || true
+          echo "[DEPLOY] Ensure venv"
+          if [ ! -x "${DST}/.venv/bin/python" ]; then
+            sudo -n python3 -m venv "${DST}/.venv"
+          fi
+          sudo -n bash -lc "${DST}/.venv/bin/pip install --upgrade pip && \
+                            [ -f ${DST}/requirements.txt ] && ${DST}/.venv/bin/pip install -r ${DST}/requirements.txt || true"
 
-            echo "[DEPLOY] One-shot run"
-            sudo -n systemctl start trader-once.service
+          echo "[DEPLOY] Install systemd units"
+          sudo -n cp "${DST}/systemd/trader-once.service" /etc/systemd/system/trader-once.service
+          sudo -n cp "${DST}/systemd/trader-once.timer"   /etc/systemd/system/trader-once.timer
 
-            echo "[DEPLOY] Status"
-            sudo -n systemctl status trader-once.timer   --no-pager || true
-            sudo -n systemctl status trader-once.service --no-pager || true
-            # 額外可觀察點：下一次觸發時間（CI log 中確認排程）
-            sudo -n systemctl list-timers --all | grep -i trader-once || true
+          # 強制建立 drop-in，保證 service 吃到 env（就算單元檔沒寫也行）
+          sudo -n mkdir -p /etc/systemd/system/trader-once.service.d
+          printf '%s\n%s\n' '[Service]' 'EnvironmentFile=-/etc/crypto_strategy_project.env' | \
+            sudo -n tee /etc/systemd/system/trader-once.service.d/override.conf >/dev/null
 
-            echo "== recent journal (last 200 lines, last 30 minutes) =="
-            if ! sudo -n journalctl -u trader-once.service --since "-30 min" -o cat | tail -n 200 ; then
-              sudo -n journalctl -u trader-once.service -n 200 -o cat || true
-            fi
+          echo "[DEPLOY] Reload & (re)start timer/service"
+          sudo -n systemctl daemon-reload
+          sudo -n systemctl enable --now trader-once.timer
+          sudo -n systemctl restart trader-once.timer
+          sudo -n systemctl stop trader-once.service || true
+          sudo -n systemctl start trader-once.service
 
-            echo "== models on VM =="
-            sudo -n bash -lc "find ${DST}/models -maxdepth 2 -type f | sort || true"
+          echo "[DEPLOY] Status"
+          sudo -n systemctl status trader-once.timer   --no-pager || true
+          sudo -n systemctl status trader-once.service --no-pager || true
+          sudo -n systemctl list-timers --all | grep -i trader-once || true
           REMOTE

--- a/systemd/trader-once.service
+++ b/systemd/trader-once.service
@@ -6,17 +6,13 @@ After=network-online.target
 [Service]
 Type=oneshot
 WorkingDirectory=/opt/crypto_strategy_project
-# 可選：若你的 daemon 以非 root 執行，請改成對應帳號
-#User=ubuntu
-# 從檔案注入 Telegram 等機密（不存在也不致命）
 EnvironmentFile=-/etc/crypto_strategy_project.env
-Environment=VIRTUAL_ENV=/opt/crypto_strategy_project/.venv
-Environment=PATH=/opt/crypto_strategy_project/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-Environment=PYTHONUNBUFFERED=1
 ExecStartPre=/opt/crypto_strategy_project/.venv/bin/python -c "import json,sys,os; p=os.path.join('/opt/crypto_strategy_project','RELEASE.json'); print(open(p).read() if os.path.exists(p) else '{\"sha\":\"file\"}')"
 ExecStartPre=/opt/crypto_strategy_project/.venv/bin/python -c "import numpy, pandas"
 ExecStart=/opt/crypto_strategy_project/.venv/bin/python /opt/crypto_strategy_project/scripts/realtime_loop.py --cfg /opt/crypto_strategy_project/csp/configs/strategy.yaml --delay-sec 15 --once
-Restart=no
+User=root
+Group=root
 
 [Install]
 WantedBy=multi-user.target
+


### PR DESCRIPTION
## Summary
- inject TELEGRAM secrets via ssh prefix and provision env file with printf
- ensure systemd drop-in loads env and restart units
- simplify trader-once service to consume env file as root

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c450dccbd8832d9cd6b3e967e56425