### PR TITLE
Fix path handling for direct script execution

### DIFF
--- a/scripts/backtest_multi.py
+++ b/scripts/backtest_multi.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 import requests
+
+# --- make imports work when invoked as "python scripts/backtest_multi.py" ---
+import os, sys
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+# --------------------------------------------------------------------------
+
 from csp.utils.diag import log_diag
 
 # 依賴 backtest_v2 的核心邏輯


### PR DESCRIPTION
## Summary
- ensure `scripts/backtest_multi.py` sets repo root on `sys.path` for direct execution

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6f6a23b44832da32cb14944579917