### PR TITLE
Add backtest execution config and refine fetcher timestamp override

### DIFF
--- a/csp/configs/strategy.yaml
+++ b/csp/configs/strategy.yaml
@@ -56,3 +56,32 @@ resources_dir: resources
 logging:
   level: INFO
   diag: true
+
+# === 開始：回測/執行必備的設定（供 backtest_v2.py 使用）===
+execution:
+  # 分類器輸出的做多/做空「機率」門檻
+  long_prob_threshold: 0.70
+  short_prob_threshold: 0.70
+  # （可選）ATR 型的 TP/SL 規則，用在回測/說明用
+  atr_tp_sl:
+    enabled: true
+    atr_period: 14
+    tp_mult: 2.0
+    sl_mult: 1.0
+  # （可選）進場區間限制（z-score 帶）
+  entry_zone:
+    enabled: false
+    length: 20
+    zscore_max: 1.5
+
+backtest:
+  maker_fee: 0.0002
+  taker_fee: 0.0004
+  max_position_hours: 12
+  sizeUsd: 100.0
+  # 與 trade.min_notional 對齊，防止名目過小
+  min_notional:
+    BTCUSDT: 5.0
+    ETHUSDT: 5.0
+    BCHUSDT: 5.0
+# === 結束：回測/執行必備的設定 ===

--- a/csp/data/fetcher.py
+++ b/csp/data/fetcher.py
@@ -103,7 +103,7 @@ def update_csv_with_latest(
     symbol: str,
     csv_path: str,
     interval: str = "15m",
-    now_utc_ts: Optional[pd.Timestamp] = None,
+    now_ts_override: Optional[pd.Timestamp] = None,
 ) -> pd.DataFrame:
     """Update local CSV with latest closed klines from Binance.
 
@@ -124,7 +124,7 @@ def update_csv_with_latest(
 
     interval_td = pd.to_timedelta(interval)
     # 若呼叫端沒提供時間，取目前 UTC；避免名稱遮蔽工具函式
-    now_ts = _now_utc() if now_utc_ts is None else safe_ts_to_utc(now_utc_ts)
+    now_ts = _now_utc() if now_ts_override is None else safe_ts_to_utc(now_ts_override)
     last_closed = floor_utc(now_ts, interval)
 
     last_ts = df.index[-1] if not df.empty else None


### PR DESCRIPTION
## Summary
- expand `strategy.yaml` with execution and backtest parameters for backtest_v2
- allow overriding current time in `update_csv_with_latest`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c780c5d0e0832d9a1c0523e20dea78