### PR TITLE
Configure Git to ignore binary artifacts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.pkl -diff
+*.joblib -diff
+*.bin -diff
+*.zip -diff
+models/** -diff
+artifacts/** -diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,18 @@
 resources/*.json
 resources/*.yaml
+
+# Model artifacts
 models/**
+!models/.gitkeep
+
 artifacts/**
+!artifacts/.gitkeep
+
+# Binary artifacts
 *.pkl
 *.joblib
 *.bin
 *.zip
-!models/.gitkeep
-!artifacts/.gitkeep
+
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary
- disable diffs for common binary artifacts and generated directories
- reorganize the Git ignore list while preserving tracked placeholder files

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dd6333373c832d909398688c83967f