### PR TITLE
Make Telegram notifier importable for CI

### DIFF
--- a/.github/workflows/model-ci.yml
+++ b/.github/workflows/model-ci.yml
@@ -41,7 +41,7 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
-          python scripts/ci_orchestrator.py \
+          python -m scripts.ci_orchestrator \
             --csv resources/btc_15m.csv \
             --feature-func csp.features.h16.build_features_15m_4h \
             --models-dir models/ci \

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ python scripts/backtest_multi.py \
 - **流程概覽**：GitHub Actions 觸發 `model-ci` workflow 後，`scripts/ci_orchestrator.py` 會先以 `scripts/train_h16_wf.py` 進行時間序交叉驗證訓練，再呼叫 `scripts/threshold_report.py` 回測門檻表現；若主要指標（預設 `roc_auc`）未達標，會自動展開小型參數搜尋（歷程紀錄於 `logs/ci_run.json`），最後依狀態透過 Telegram 通知。
 - **觸發方式**：支援 push（`main`、`work`、`ci/**`）、Pull Request、排程（週一 03:00 UTC）以及 workflow_dispatch 手動觸發。
 - **GitHub Secrets**：必須在專案設定中加入 `TELEGRAM_BOT_TOKEN` 以及 `TELEGRAM_CHAT_ID` 才能接收通知；若未設定將僅在 CI console 顯示結果。
+- **環境需求**：請確保保留 `scripts/__init__.py`（供 `python -m scripts.ci_orchestrator` 匯入）並安裝 `requests` 套件；CI 成功或失敗都會透過 Telegram 推播結果。
 - **產出物**：
   - `logs/ci_run.json`：詳細記錄各次訓練、回測、門檻掃描與參數搜尋狀態，供失敗時貼給 ChatGPT 進行問題排查。
   - `logs/threshold_report.json`：最佳門檻的覆蓋率、Precision/F1 與平均報酬。

--- a/scripts/ci_orchestrator.py
+++ b/scripts/ci_orchestrator.py
@@ -14,7 +14,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
-from scripts.notify_telegram import send_telegram_message
+try:
+    from scripts.notify_telegram import send_telegram_message
+except Exception:  # noqa: BLE001
+    import sys
+
+    sys.path.append(os.path.dirname(__file__))
+    from notify_telegram import send_telegram_message  # type: ignore[import-not-found]
 from scripts.train_h16_wf import (
     TrainingDataset,
     prepare_training_dataset,
@@ -209,7 +215,7 @@ def main() -> None:
     if token and chat_id and _should_notify(args.notify, ci_log["success"]):
         message = _compose_message(ci_log["success"], args.target_metric, args.target_value, best_run, logs_path)
         try:
-            send_telegram_message(token, chat_id, message)
+            send_telegram_message(message, token=token, chat_id=chat_id)
         except Exception:  # noqa: BLE001
             # We do not want notification failures to fail the CI job.
             print("Failed to send Telegram notification:")

--- a/scripts/notify_telegram.py
+++ b/scripts/notify_telegram.py
@@ -1,4 +1,10 @@
-"""Utility helpers for sending Telegram notifications."""
+"""Telegram notification helpers.
+
+This module can be imported both from scripts and from other modules while
+still supporting CLI usage.  The :func:`send_telegram_message` helper reads the
+Telegram credentials from arguments or environment variables, which allows it to
+be reused in CI contexts where the script is executed as a module.
+"""
 from __future__ import annotations
 
 import argparse
@@ -7,55 +13,61 @@ from typing import Any, Dict
 
 import requests
 
+__all__ = ["send_telegram_message"]
 
-def send_telegram_message(
-    token: str,
-    chat_id: str,
-    message: str,
-    parse_mode: str | None = "Markdown",
-    disable_notification: bool = False,
-) -> Dict[str, Any]:
+
+def send_telegram_message(text: str, token: str | None = None, chat_id: str | None = None) -> Dict[str, Any]:
+    """Send a Telegram message using the Bot API.
+
+    Parameters
+    ----------
+    text:
+        Message body to send.  Markdown formatting is enabled by default.
+    token:
+        Telegram bot token.  Falls back to the ``TELEGRAM_BOT_TOKEN``
+        environment variable when omitted.
+    chat_id:
+        Target chat ID.  Falls back to the ``TELEGRAM_CHAT_ID`` environment
+        variable when omitted.
+    """
+
+    token = token or os.environ.get("TELEGRAM_BOT_TOKEN")
+    chat_id = chat_id or os.environ.get("TELEGRAM_CHAT_ID")
+
     if not token:
         raise ValueError("Telegram token is required")
     if not chat_id:
         raise ValueError("Telegram chat_id is required")
-    if not message:
-        raise ValueError("message must not be empty")
+    if not text:
+        raise ValueError("text must not be empty")
 
     url = f"https://api.telegram.org/bot{token}/sendMessage"
     payload: Dict[str, Any] = {
         "chat_id": chat_id,
-        "text": message,
-        "disable_notification": disable_notification,
+        "text": text,
+        "parse_mode": "Markdown",
     }
-    if parse_mode:
-        payload["parse_mode"] = parse_mode
 
     response = requests.post(url, json=payload, timeout=15)
     response.raise_for_status()
+
     data = response.json()
     if not data.get("ok", False):
         raise RuntimeError(f"Telegram API returned error: {data}")
     return data
 
 
-def main() -> None:
+def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Send a Telegram message")
-    parser.add_argument("--token", default=os.environ.get("TELEGRAM_BOT_TOKEN"))
-    parser.add_argument("--chat-id", default=os.environ.get("TELEGRAM_CHAT_ID"))
-    parser.add_argument("--message", required=True)
-    parser.add_argument("--disable-notification", action="store_true")
-    parser.add_argument("--no-parse-mode", action="store_true")
+    parser.add_argument("--message", required=True, help="Message text")
+    parser.add_argument("--token", default=None, help="Telegram bot token")
+    parser.add_argument("--chat-id", default=None, help="Telegram chat ID")
+    return parser.parse_args()
 
-    args = parser.parse_args()
-    parse_mode = None if args.no_parse_mode else "Markdown"
-    send_telegram_message(
-        token=args.token,
-        chat_id=args.chat_id,
-        message=args.message,
-        parse_mode=parse_mode,
-        disable_notification=args.disable_notification,
-    )
+
+def main() -> None:
+    args = _parse_args()
+    send_telegram_message(args.message, token=args.token, chat_id=args.chat_id)
     print("Message sent")
 
 


### PR DESCRIPTION
## Summary
- refactor scripts/notify_telegram.py into an importable helper that exposes send_telegram_message for reuse
- update CI orchestrator to import the helper reliably and to call it with explicit keyword arguments
- run the model-ci workflow via python -m entrypoint and document the Telegram requirements in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12c9b7ffc832db795e506d69e9d1c