### PR TITLE
Fix return scaling and improve CI Telegram notifications

### DIFF
--- a/.github/workflows/model-ci.yml
+++ b/.github/workflows/model-ci.yml
@@ -73,3 +73,11 @@ jobs:
           name: model-ci-artifacts
           path: artifacts/ci
           if-no-files-found: warn
+
+      - name: Telegram notify (always)
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          python -m scripts.ci_notify_from_log

--- a/csp/metrics/report.py
+++ b/csp/metrics/report.py
@@ -64,10 +64,8 @@ def summarize(equity_curve: pd.DataFrame, trades: pd.DataFrame, bar_seconds: int
 
     # --- Annualized return ---
     if start_time is not None and end_time is not None and end_time > start_time:
-        duration_seconds = (end_time - start_time).total_seconds()
-        years = duration_seconds / (365.25 * 24 * 3600)
-        if years > 0:
-            metrics["annual_return"] = float((1 + total_return) ** (1 / years) - 1)
+        n_days = max((end_time - start_time).total_seconds() / 86400.0, 1e-9)
+        metrics["annual_return"] = float((1.0 + total_return) ** (365.0 / n_days) - 1.0)
 
     # --- Max drawdown ---
     if not eq_df.empty and "equity_after" in eq_df.columns:

--- a/csp/optimize/feature_opt.py
+++ b/csp/optimize/feature_opt.py
@@ -44,7 +44,7 @@ def optimize_symbol(cfg_path: str, symbol: str,
         # merge with base feature params (e.g., ema_windows)
         merged = {**base_feature, **params}
         res = walk_forward_evaluate(cfg_path, symbol, start_ts, end_ts, merged)
-        metric = res.get("metrics", {}).get("總報酬率%", 0.0)
+        metric = res.get("metrics", {}).get("總報酬率", 0.0)
         trial.set_user_attr("metrics", res.get("metrics", {}))
         return float(metric)
 

--- a/scripts/ci_notify_from_log.py
+++ b/scripts/ci_notify_from_log.py
@@ -1,0 +1,34 @@
+import json, os, re
+from scripts.notify_telegram import send_telegram_message
+
+
+def main():
+    msg = "❌ CI失敗：沒有找到 logs/ci_run.json"
+    try:
+        log_path = os.path.join("logs", "ci_run.json")
+        if not os.path.exists(log_path):
+            raise FileNotFoundError(log_path)
+        data = json.load(open(log_path, "r", encoding="utf-8"))
+        hit = bool(data.get("hit_target", False))
+        best = data.get("best", {})
+        # 盡力在 steps tail 裡找 "[SUMMARY ALL] {json}"，若有就原樣發送
+        summary_line = None
+        for s in data.get("steps", []):
+            for line in s.get("tail", "").splitlines():
+                if re.match(r"^\[SUMMARY ALL\]", line):
+                    summary_line = line
+        if summary_line:
+            msg = summary_line  # 你要的格式
+        else:
+            win = float(best.get("win_rate", 0.0))
+            ret = float(best.get("total_return", 0.0))
+            badge = "✅ 達標" if hit else "❌ 未達標"
+            msg = f"[RESULT] {badge} | win_rate={win:.2%} total_return={ret:.2%} | thr={best.get('threshold')}"
+    except Exception as e:
+        msg = f"❌ CI失敗：讀取/解析 logs 失敗：{e}"
+    print(msg)
+    send_telegram_message(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/notify_telegram.py
+++ b/scripts/notify_telegram.py
@@ -1,75 +1,16 @@
-"""Telegram notification helpers.
-
-This module can be imported both from scripts and from other modules while
-still supporting CLI usage.  The :func:`send_telegram_message` helper reads the
-Telegram credentials from arguments or environment variables, which allows it to
-be reused in CI contexts where the script is executed as a module.
-"""
-from __future__ import annotations
-
-import argparse
 import os
-from typing import Any, Dict
-
 import requests
 
-__all__ = ["send_telegram_message"]
 
-
-def send_telegram_message(text: str, token: str | None = None, chat_id: str | None = None) -> Dict[str, Any]:
-    """Send a Telegram message using the Bot API.
-
-    Parameters
-    ----------
-    text:
-        Message body to send.  Markdown formatting is enabled by default.
-    token:
-        Telegram bot token.  Falls back to the ``TELEGRAM_BOT_TOKEN``
-        environment variable when omitted.
-    chat_id:
-        Target chat ID.  Falls back to the ``TELEGRAM_CHAT_ID`` environment
-        variable when omitted.
-    """
-
-    token = token or os.environ.get("TELEGRAM_BOT_TOKEN")
-    chat_id = chat_id or os.environ.get("TELEGRAM_CHAT_ID")
-
-    if not token:
-        raise ValueError("Telegram token is required")
-    if not chat_id:
-        raise ValueError("Telegram chat_id is required")
-    if not text:
-        raise ValueError("text must not be empty")
-
-    url = f"https://api.telegram.org/bot{token}/sendMessage"
-    payload: Dict[str, Any] = {
-        "chat_id": chat_id,
-        "text": text,
-        "parse_mode": "Markdown",
-    }
-
-    response = requests.post(url, json=payload, timeout=15)
-    response.raise_for_status()
-
-    data = response.json()
-    if not data.get("ok", False):
-        raise RuntimeError(f"Telegram API returned error: {data}")
-    return data
-
-
-def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Send a Telegram message")
-    parser.add_argument("--message", required=True, help="Message text")
-    parser.add_argument("--token", default=None, help="Telegram bot token")
-    parser.add_argument("--chat-id", default=None, help="Telegram chat ID")
-    return parser.parse_args()
-
-
-def main() -> None:
-    args = _parse_args()
-    send_telegram_message(args.message, token=args.token, chat_id=args.chat_id)
-    print("Message sent")
+def send_telegram_message(text: str, token: str = None, chat_id: str = None) -> bool:
+    tok = token or os.environ.get("TELEGRAM_BOT_TOKEN")
+    chat = chat_id or os.environ.get("TELEGRAM_CHAT_ID")
+    if not tok or not chat:
+        print("[TG][WARN] Missing TELEGRAM_*"); return False
+    r = requests.post(f"https://api.telegram.org/bot{tok}/sendMessage",
+                      json={"chat_id": chat, "text": text, "parse_mode": "Markdown"}, timeout=20)
+    print("[TG]", r.status_code, r.text[:200]); return r.ok
 
 
 if __name__ == "__main__":
-    main()
+    import sys; send_telegram_message(sys.argv[1] if len(sys.argv)>1 else "(empty)")

--- a/scripts/train_h16_wf.py
+++ b/scripts/train_h16_wf.py
@@ -185,18 +185,25 @@ def scan_thresholds(
             precision = recall = f1 = 0.0
             avg_return = float("nan")
             median_return = float("nan")
+            win_rate = 0.0
+            total_return = 0.0
         else:
             preds = mask.astype(int)
             precision = precision_score(labels_arr, preds, zero_division=0)
             recall = recall_score(labels_arr, preds, zero_division=0)
             f1 = f1_score(labels_arr, preds, zero_division=0)
             sub_returns = returns_arr[mask]
-            avg_return = float(np.nanmean(sub_returns)) if np.isfinite(sub_returns).any() else float("nan")
-            median_return = (
-                float(np.nanmedian(sub_returns))
-                if np.isfinite(sub_returns).any()
-                else float("nan")
-            )
+            valid_returns = sub_returns[np.isfinite(sub_returns)]
+            if valid_returns.size:
+                avg_return = float(np.nanmean(valid_returns))
+                median_return = float(np.nanmedian(valid_returns))
+                win_rate = float(np.mean(valid_returns > 0))
+                total_return = float(np.prod(1.0 + valid_returns) - 1.0)
+            else:
+                avg_return = float("nan")
+                median_return = float("nan")
+                win_rate = 0.0
+                total_return = 0.0
         rows.append(
             {
                 "threshold": float(thr),
@@ -207,6 +214,8 @@ def scan_thresholds(
                 "f1": float(f1),
                 "avg_return": avg_return,
                 "median_return": median_return,
+                "win_rate": float(win_rate),
+                "total_return": float(total_return),
             }
         )
 


### PR DESCRIPTION
## Summary
- normalize backtest metrics to operate on decimal returns, refresh annualized return logic, and surface win/total return data from threshold scanning
- add reusable Telegram notification helpers, a CI log notifier, and extend the orchestrator to persist hit_target metadata for downstream alerts
- document the notification behavior/secrets and ensure the CI workflow always invokes the log-based Telegram notifier

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54fce860c832d8bcea439d246127f